### PR TITLE
compiler: always use main symbol prefix

### DIFF
--- a/chore/litgen/litgen_test.go
+++ b/chore/litgen/litgen_test.go
@@ -5,16 +5,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/goplus/mod"
 )
 
 func TestProcessPath_SingleFileUsesContainingDir(t *testing.T) {
 	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	root, _, err := mod.FindGoMod(wd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +20,10 @@ func TestProcessPath_SingleFileUsesContainingDir(t *testing.T) {
 		_ = os.RemoveAll(pkgDir)
 	})
 	sourceFile := filepath.Join(pkgDir, "in.go")
-	if err := os.WriteFile(sourceFile, []byte("// LITTEST\npackage main\n\nfunc main() {}\n"), 0644); err != nil {
+	if err := os.WriteFile(sourceFile, []byte("// LITTEST\npackage main\n\nfunc main() { helper() }\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "helper.go"), []byte("package main\n\nfunc helper() {}\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -42,12 +39,11 @@ func TestProcessPath_SingleFileUsesContainingDir(t *testing.T) {
 	if strings.Contains(text, "command-line-arguments") {
 		t.Fatalf("single-file mode should compile the containing package, got:\n%s", text)
 	}
-	relPath, err := filepath.Rel(root, pkgDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := `// CHECK-LABEL: define void @"{{.*}}/` + filepath.ToSlash(relPath) + `.main"(){{.*}} {`
+	want := `// CHECK-LABEL: define void @main.main(){{.*}} {`
 	if !strings.Contains(text, want) {
-		t.Fatalf("missing package-qualified main check:\n%s", text)
+		t.Fatalf("missing canonical main check:\n%s", text)
+	}
+	if !strings.Contains(text, `call void @main.helper()`) {
+		t.Fatalf("single-file mode did not include the containing package:\n%s", text)
 	}
 }

--- a/chore/llgen/llgen.go
+++ b/chore/llgen/llgen.go
@@ -27,8 +27,7 @@ import (
 )
 
 var (
-	abi               = flag.Int("abi", 0, "ABI mode (default 0). 0 = none, 1 = cfunc, 2 = allfunc.")
-	rewriteMainPrefix = flag.Bool("rewrite-main-prefix", false, "Rewrite symbol names in the main package from 'pkgpath.sym' to 'main.sym'.")
+	abi = flag.Int("abi", 0, "ABI mode (default 0). 0 = none, 1 = cfunc, 2 = allfunc.")
 )
 
 func main() {
@@ -38,5 +37,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Usage: llgen [flags] <pkg>")
 		return
 	}
-	llgen.SmartDoFileEx(flag.Args()[0], build.AbiMode(*abi), *rewriteMainPrefix)
+	llgen.SmartDoFileEx(flag.Args()[0], build.AbiMode(*abi))
 }

--- a/cl/_testdata/cpkgimp/in.go
+++ b/cl/_testdata/cpkgimp/in.go
@@ -5,7 +5,7 @@ import (
 	c "github.com/goplus/llgo/cl/_testdata/cpkg"
 )
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i64 @add(i64 1, i64 2)
 // CHECK-NEXT:   %1 = call double @Double(double 3.140000e+00)

--- a/cl/_testdata/fncall/in.go
+++ b/cl/_testdata/fncall/in.go
@@ -1,16 +1,16 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i64 @"{{.*}}.max"(i64 1, i64 2)
+// CHECK-NEXT:   %0 = call i64 @main.max(i64 1, i64 2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {
 	_ = max(1, 2)
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}.max"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.max(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp sgt i64 %0, %1
 // CHECK-NEXT:   br i1 %2, label %_llgo_1, label %_llgo_2

--- a/cl/_testdata/importpkg/in.go
+++ b/cl/_testdata/importpkg/in.go
@@ -3,23 +3,23 @@ package main
 
 import "github.com/goplus/llgo/cl/_testdata/importpkg/stdio"
 
-// CHECK: @"{{.*}}.hello" = global [7 x i8] c"Hello\0A\00", align 1
+// CHECK: @main.hello = global [7 x i8] c"Hello\0A\00", align 1
 
-// CHECK-LABEL: define void @"{{.*}}.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:{{.*}}
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @"{{.*}}/stdio.init"()
 // CHECK-NEXT:   br label %_llgo_2
 var hello = [...]int8{'H', 'e', 'l', 'l', 'o', '\n', 0}
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i64 @"{{.*}}/stdio.Max"(i64 2, i64 100)
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}.hello")
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.hello)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testdata/method/in.go
+++ b/cl/_testdata/method/in.go
@@ -5,11 +5,11 @@ import _ "unsafe"
 
 // CHECK-DAG: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testdata/method.T", align 1{{$}}
 // CHECK-DAG: {{^}}@1 = private unnamed_addr constant [3 x i8] c"Add", align 1{{$}}
-// CHECK-DAG: @"{{.*}}/cl/_testdata/method.format" = global [10 x i8] c"Hello %d\0A\00", align 1
+// CHECK-DAG: @main.format = global [10 x i8] c"Hello %d\0A\00", align 1
 
 type T int
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testdata/method.T.Add"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.T.Add(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
@@ -29,31 +29,31 @@ func main() {
 	printf(&format[0], a.Add(2))
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testdata/method.(*T).Add"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T).Add"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 44 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 3 })
 // CHECK-NEXT:   %3 = load i64, ptr %0, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testdata/method.T.Add"(i64 %3, i64 %1)
+// CHECK-NEXT:   %4 = call i64 @main.T.Add(i64 %3, i64 %1)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/method.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testdata/method.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testdata/method.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/method.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i64 @"{{.*}}/cl/_testdata/method.T.Add"(i64 1, i64 2)
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}/cl/_testdata/method.format", i64 %0)
+// CHECK-NEXT:   %0 = call i64 @main.T.Add(i64 1, i64 2)
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i64 %0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testdata/print/in.go
+++ b/cl/_testdata/print/in.go
@@ -36,23 +36,23 @@ type stringStruct struct {
 	len int
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testdata/print.bytes"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @main.bytes(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/cl/_testdata/print.stringStructOf"(ptr %1)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testdata/print.stringStruct", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %3 = call ptr @main.stringStructOf(ptr %1)
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.stringStruct, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   %5 = load ptr, ptr %4, align 8
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testdata/print.slice", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.slice, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   store ptr %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testdata/print.stringStruct", ptr %3, i32 0, i32 1
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.stringStruct, ptr %3, i32 0, i32 1
 // CHECK-NEXT:   %8 = load i64, ptr %7, align 8
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testdata/print.slice", ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.slice, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   store i64 %8, ptr %9, align 8
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testdata/print.stringStruct", ptr %3, i32 0, i32 1
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.stringStruct, ptr %3, i32 0, i32 1
 // CHECK-NEXT:   %11 = load i64, ptr %10, align 8
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testdata/print.slice", ptr %2, i32 0, i32 2
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.slice, ptr %2, i32 0, i32 2
 // CHECK-NEXT:   store i64 %11, ptr %12, align 8
 // CHECK-NEXT:   %13 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %2, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %13
@@ -67,7 +67,7 @@ func bytes(s string) (ret []byte) {
 	return
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.gwrite"(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
+// CHECK-LABEL: define void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   %2 = icmp eq i64 %1, 0
@@ -102,13 +102,13 @@ func bytes(s string) (ret []byte) {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testdata/print.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testdata/print.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -124,32 +124,32 @@ func gwrite(b []byte) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 4 })
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 1024)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printhex"(i64 305441743)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.prinxor"(i64 1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.prinsub"(i64 100)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.prinusub"(i64 -1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.prinfsub"(double 1.001000e+02)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 4 })
+// CHECK-NEXT:   call void @main.printnl()
+// CHECK-NEXT:   call void @main.printuint(i64 1024)
+// CHECK-NEXT:   call void @main.printnl()
+// CHECK-NEXT:   call void @main.printhex(i64 305441743)
+// CHECK-NEXT:   call void @main.printnl()
+// CHECK-NEXT:   call void @main.prinxor(i64 1)
+// CHECK-NEXT:   call void @main.printnl()
+// CHECK-NEXT:   call void @main.prinsub(i64 100)
+// CHECK-NEXT:   call void @main.printnl()
+// CHECK-NEXT:   call void @main.prinusub(i64 -1)
+// CHECK-NEXT:   call void @main.printnl()
+// CHECK-NEXT:   call void @main.prinfsub(double 1.001000e+02)
+// CHECK-NEXT:   call void @main.printnl()
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 4)
 // CHECK-NEXT:   store float 1.000000e+09, ptr %0, align 4
 // CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_float32, ptr undef }, ptr %0, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printany"(%"{{.*}}/runtime/internal/runtime.eface" %1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
+// CHECK-NEXT:   call void @main.printany(%"{{.*}}/runtime/internal/runtime.eface" %1)
+// CHECK-NEXT:   call void @main.printnl()
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store double 2.000000e+09, ptr %2, align 8
 // CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_float64, ptr undef }, ptr %2, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printany"(%"{{.*}}/runtime/internal/runtime.eface" %3)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
+// CHECK-NEXT:   call void @main.printany(%"{{.*}}/runtime/internal/runtime.eface" %3)
+// CHECK-NEXT:   call void @main.printnl()
 // CHECK-NEXT:   br i1 true, label %_llgo_3, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_3
@@ -167,7 +167,7 @@ func gwrite(b []byte) {
 // CHECK-NEXT:   %11 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %4, 0
 // CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %11, i64 2, 1
 // CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %12, i64 2, 2
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.println"(%"{{.*}}/runtime/internal/runtime.Slice" %13)
+// CHECK-NEXT:   call void @main.println(%"{{.*}}/runtime/internal/runtime.Slice" %13)
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_3, %_llgo_0
@@ -190,7 +190,7 @@ func gwrite(b []byte) {
 // CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %14, 0
 // CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %24, i64 3, 1
 // CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %25, i64 3, 2
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.println"(%"{{.*}}/runtime/internal/runtime.Slice" %26)
+// CHECK-NEXT:   call void @main.println(%"{{.*}}/runtime/internal/runtime.Slice" %26)
 // CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 256)
 // CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %27, i64 0
 // CHECK-NEXT:   %29 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 1)
@@ -275,7 +275,7 @@ func gwrite(b []byte) {
 // CHECK-NEXT:   %76 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %27, 0
 // CHECK-NEXT:   %77 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %76, i64 16, 1
 // CHECK-NEXT:   %78 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %77, i64 16, 2
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.println"(%"{{.*}}/runtime/internal/runtime.Slice" %78)
+// CHECK-NEXT:   call void @main.println(%"{{.*}}/runtime/internal/runtime.Slice" %78)
 // CHECK-NEXT:   %79 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %80 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %79, i64 0
 // CHECK-NEXT:   %81 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
@@ -285,7 +285,7 @@ func gwrite(b []byte) {
 // CHECK-NEXT:   %83 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %79, 0
 // CHECK-NEXT:   %84 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %83, i64 1, 1
 // CHECK-NEXT:   %85 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %84, i64 1, 2
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.println"(%"{{.*}}/runtime/internal/runtime.Slice" %85)
+// CHECK-NEXT:   call void @main.println(%"{{.*}}/runtime/internal/runtime.Slice" %85)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
@@ -325,10 +325,10 @@ func main() {
 	println(1 + 2i)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.prinfsub"(double %0){{.*}} {
+// CHECK-LABEL: define void @main.prinfsub(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = fneg double %0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printfloat"(double %1)
+// CHECK-NEXT:   call void @main.printfloat(double %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -336,10 +336,10 @@ func prinfsub(n float64) {
 	printfloat(-n)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.prinsub"(i64 %0){{.*}} {
+// CHECK-LABEL: define void @main.prinsub(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = sub i64 0, %0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printint"(i64 %1)
+// CHECK-NEXT:   call void @main.printint(i64 %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -347,7 +347,7 @@ func prinsub(n int64) {
 	printint(-n)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printany"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
+// CHECK-LABEL: define void @main.printany(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %0, 0
 // CHECK-NEXT:   %2 = icmp eq ptr %1, @_llgo_bool
@@ -357,7 +357,7 @@ func prinsub(n int64) {
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_37
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printbool"(i1 %53)
+// CHECK-NEXT:   call void @main.printbool(i1 %53)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_37
@@ -366,7 +366,7 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %4, label %_llgo_38, label %_llgo_39
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_40
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printint"(i64 %60)
+// CHECK-NEXT:   call void @main.printint(i64 %60)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_40
@@ -376,7 +376,7 @@ func prinsub(n int64) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_43
 // CHECK-NEXT:   %7 = sext i8 %67 to i64
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printint"(i64 %7)
+// CHECK-NEXT:   call void @main.printint(i64 %7)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_43
@@ -386,7 +386,7 @@ func prinsub(n int64) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_46
 // CHECK-NEXT:   %10 = sext i16 %74 to i64
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printint"(i64 %10)
+// CHECK-NEXT:   call void @main.printint(i64 %10)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_46
@@ -396,7 +396,7 @@ func prinsub(n int64) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_49
 // CHECK-NEXT:   %13 = sext i32 %81 to i64
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printint"(i64 %13)
+// CHECK-NEXT:   call void @main.printint(i64 %13)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_49
@@ -405,7 +405,7 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %15, label %_llgo_50, label %_llgo_51
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_52
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printint"(i64 %88)
+// CHECK-NEXT:   call void @main.printint(i64 %88)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_52
@@ -414,7 +414,7 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %17, label %_llgo_53, label %_llgo_54
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_55
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 %95)
+// CHECK-NEXT:   call void @main.printuint(i64 %95)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_55
@@ -424,7 +424,7 @@ func prinsub(n int64) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_58
 // CHECK-NEXT:   %20 = zext i8 %102 to i64
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 %20)
+// CHECK-NEXT:   call void @main.printuint(i64 %20)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_17:                                         ; preds = %_llgo_58
@@ -434,7 +434,7 @@ func prinsub(n int64) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_18:                                         ; preds = %_llgo_61
 // CHECK-NEXT:   %23 = zext i16 %109 to i64
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 %23)
+// CHECK-NEXT:   call void @main.printuint(i64 %23)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_19:                                         ; preds = %_llgo_61
@@ -444,7 +444,7 @@ func prinsub(n int64) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_20:                                         ; preds = %_llgo_64
 // CHECK-NEXT:   %26 = zext i32 %116 to i64
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 %26)
+// CHECK-NEXT:   call void @main.printuint(i64 %26)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_21:                                         ; preds = %_llgo_64
@@ -453,7 +453,7 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %28, label %_llgo_65, label %_llgo_66
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_67
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 %123)
+// CHECK-NEXT:   call void @main.printuint(i64 %123)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_23:                                         ; preds = %_llgo_67
@@ -462,7 +462,7 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %30, label %_llgo_68, label %_llgo_69
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_24:                                         ; preds = %_llgo_70
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 %130)
+// CHECK-NEXT:   call void @main.printuint(i64 %130)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_25:                                         ; preds = %_llgo_70
@@ -472,7 +472,7 @@ func prinsub(n int64) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_26:                                         ; preds = %_llgo_73
 // CHECK-NEXT:   %33 = fpext float %137 to double
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printfloat"(double %33)
+// CHECK-NEXT:   call void @main.printfloat(double %33)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_27:                                         ; preds = %_llgo_73
@@ -481,7 +481,7 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %35, label %_llgo_74, label %_llgo_75
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_28:                                         ; preds = %_llgo_76
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printfloat"(double %144)
+// CHECK-NEXT:   call void @main.printfloat(double %144)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_29:                                         ; preds = %_llgo_76
@@ -490,14 +490,14 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %37, label %_llgo_77, label %_llgo_78
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_30:                                         ; preds = %_llgo_79
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 1 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 1 })
 // CHECK-NEXT:   %38 = extractvalue { float, float } %151, 0
 // CHECK-NEXT:   %39 = fpext float %38 to double
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printfloat"(double %39)
+// CHECK-NEXT:   call void @main.printfloat(double %39)
 // CHECK-NEXT:   %40 = extractvalue { float, float } %151, 1
 // CHECK-NEXT:   %41 = fpext float %40 to double
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printfloat"(double %41)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 2 })
+// CHECK-NEXT:   call void @main.printfloat(double %41)
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 2 })
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_31:                                         ; preds = %_llgo_79
@@ -506,12 +506,12 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %43, label %_llgo_80, label %_llgo_81
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_32:                                         ; preds = %_llgo_82
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 1 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 1 })
 // CHECK-NEXT:   %44 = extractvalue { double, double } %158, 0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printfloat"(double %44)
+// CHECK-NEXT:   call void @main.printfloat(double %44)
 // CHECK-NEXT:   %45 = extractvalue { double, double } %158, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printfloat"(double %45)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 2 })
+// CHECK-NEXT:   call void @main.printfloat(double %45)
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 2 })
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_33:                                         ; preds = %_llgo_82
@@ -520,7 +520,7 @@ func prinsub(n int64) {
 // CHECK-NEXT:   br i1 %47, label %_llgo_83, label %_llgo_84
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_34:                                         ; preds = %_llgo_85
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" %165)
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" %165)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_35:                                         ; preds = %_llgo_0
@@ -841,19 +841,19 @@ func printany(v any) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printbool"(i1 %0){{.*}} {
+// CHECK-LABEL: define void @main.printbool(i1 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   br i1 %0, label %_llgo_1, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 4 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 4 })
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_3, %_llgo_1
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 5 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 5 })
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-NEXT: }
 
@@ -865,17 +865,17 @@ func printbool(v bool) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printfloat"(double %0){{.*}} {
+// CHECK-LABEL: define void @main.printfloat(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = fcmp une double %0, %0
 // CHECK-NEXT:   br i1 %1, label %_llgo_1, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 3 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 3 })
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_7
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 4 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 4 })
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
@@ -884,7 +884,7 @@ func printbool(v bool) {
 // CHECK-NEXT:   br i1 %3, label %_llgo_6, label %_llgo_7
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_10
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 4 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 4 })
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_7
@@ -1059,7 +1059,7 @@ func printbool(v bool) {
 // CHECK-NEXT:   %87 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %8, 0
 // CHECK-NEXT:   %88 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %87, i64 14, 1
 // CHECK-NEXT:   %89 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %88, i64 14, 2
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.gwrite"(%"{{.*}}/runtime/internal/runtime.Slice" %89)
+// CHECK-NEXT:   call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" %89)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -1135,7 +1135,7 @@ func printfloat(v float64) {
 	gwrite(buf[:])
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printhex"(i64 %0){{.*}} {
+// CHECK-LABEL: define void @main.printhex(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 100)
 // CHECK-NEXT:   br label %_llgo_3
@@ -1171,7 +1171,7 @@ func printfloat(v float64) {
 // CHECK-NEXT:   %20 = getelementptr inbounds i8, ptr %1, i64 %16
 // CHECK-NEXT:   store i8 48, ptr %20, align 1
 // CHECK-NEXT:   %21 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr %1, i64 1, i64 100, i64 %16, i64 100, i1 true, i1 true, i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.gwrite"(%"{{.*}}/runtime/internal/runtime.Slice" %21)
+// CHECK-NEXT:   call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" %21)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_4, %_llgo_0
@@ -1187,7 +1187,7 @@ func printfloat(v float64) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %27 = sub i64 100, %23
-// CHECK-NEXT:   %28 = load i64, ptr @"{{.*}}/cl/_testdata/print.minhexdigits", align 8
+// CHECK-NEXT:   %28 = load i64, ptr @main.minhexdigits, align 8
 // CHECK-NEXT:   %29 = icmp sge i64 %27, %28
 // CHECK-NEXT:   br i1 %29, label %_llgo_2, label %_llgo_4
 // CHECK-NEXT: }
@@ -1210,19 +1210,19 @@ func printhex(v uint64) {
 	gwrite(buf[i:])
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printint"(i64 %0){{.*}} {
+// CHECK-LABEL: define void @main.printint(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp slt i64 %0, 0
 // CHECK-NEXT:   br i1 %1, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 1 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 1 })
 // CHECK-NEXT:   %2 = sub i64 0, %0
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   %3 = phi i64 [ %0, %_llgo_0 ], [ %2, %_llgo_1 ]
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 %3)
+// CHECK-NEXT:   call void @main.printuint(i64 %3)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -1234,7 +1234,7 @@ func printint(v int64) {
 	printuint(uint64(v))
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.println"(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
+// CHECK-LABEL: define void @main.println(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   br label %_llgo_1
@@ -1258,15 +1258,15 @@ func printint(v int64) {
 // CHECK-NEXT:   br i1 %12, label %_llgo_4, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printnl"()
+// CHECK-NEXT:   call void @main.printnl()
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 1 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 1 })
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4, %_llgo_2
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printany"(%"{{.*}}/runtime/internal/runtime.eface" %11)
+// CHECK-NEXT:   call void @main.printany(%"{{.*}}/runtime/internal/runtime.eface" %11)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-NEXT: }
 
@@ -1280,9 +1280,9 @@ func println(args ...any) {
 	printnl()
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printnl"(){{.*}} {
+// CHECK-LABEL: define void @main.printnl(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @31, i64 1 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @31, i64 1 })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -1290,9 +1290,9 @@ func printnl() {
 	printstring("\n")
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printsp"(){{.*}} {
+// CHECK-LABEL: define void @main.printsp(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 1 })
+// CHECK-NEXT:   call void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 1 })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -1300,10 +1300,10 @@ func printsp() {
 	printstring(" ")
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printstring"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
+// CHECK-LABEL: define void @main.printstring(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testdata/print.bytes"(%"{{.*}}/runtime/internal/runtime.String" %0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.gwrite"(%"{{.*}}/runtime/internal/runtime.Slice" %1)
+// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.Slice" @main.bytes(%"{{.*}}/runtime/internal/runtime.String" %0)
+// CHECK-NEXT:   call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -1311,7 +1311,7 @@ func printstring(s string) {
 	gwrite(bytes(s))
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.printuint"(i64 %0){{.*}} {
+// CHECK-LABEL: define void @main.printuint(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 100)
 // CHECK-NEXT:   br label %_llgo_3
@@ -1331,7 +1331,7 @@ func printstring(s string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_3
 // CHECK-NEXT:   %10 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr %1, i64 1, i64 100, i64 %12, i64 100, i1 true, i1 true, i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.gwrite"(%"{{.*}}/runtime/internal/runtime.Slice" %10)
+// CHECK-NEXT:   call void @main.gwrite(%"{{.*}}/runtime/internal/runtime.Slice" %10)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_4, %_llgo_0
@@ -1359,10 +1359,10 @@ func printuint(v uint64) {
 	gwrite(buf[i:])
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.prinusub"(i64 %0){{.*}} {
+// CHECK-LABEL: define void @main.prinusub(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = sub i64 0, %0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printuint"(i64 %1)
+// CHECK-NEXT:   call void @main.printuint(i64 %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -1370,10 +1370,10 @@ func prinusub(n uint64) {
 	printuint(-n)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/print.prinxor"(i64 %0){{.*}} {
+// CHECK-LABEL: define void @main.prinxor(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = xor i64 %0, -1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/print.printint"(i64 %1)
+// CHECK-NEXT:   call void @main.printint(i64 %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -1381,7 +1381,7 @@ func prinxor(n int64) {
 	printint(^n)
 }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testdata/print.stringStructOf"(ptr %0){{.*}} {
+// CHECK-LABEL: define ptr @main.stringStructOf(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret ptr %0
 // CHECK-NEXT: }

--- a/cl/_testdata/printf/in.go
+++ b/cl/_testdata/printf/in.go
@@ -8,9 +8,9 @@ func printf(format *int8, __llgo_va_list ...any)
 
 var hello = [...]int8{'H', 'e', 'l', 'l', 'o', '\n', 0}
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}.hello")
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.hello)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testdata/printval/in.go
+++ b/cl/_testdata/printval/in.go
@@ -8,9 +8,9 @@ func printf(format *int8, __llgo_va_list ...any)
 
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}.format", i64 100)
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i64 100)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testdata/ptrmthd/in.go
+++ b/cl/_testdata/ptrmthd/in.go
@@ -8,7 +8,7 @@ func printf(format *int8, __llgo_va_list ...any)
 
 type T int8
 
-// CHECK-LABEL: define void @"{{.*}}.(*T).Print"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"main.(*T).Print"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void (ptr, ...) @printf(ptr %0, i64 %1)
 // CHECK-NEXT:   ret void
@@ -19,9 +19,9 @@ func (f *T) Print(v int) {
 
 var format = [...]T{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}.(*T).Print"(ptr @"{{.*}}.format", i64 100)
+// CHECK-NEXT:   call void @"main.(*T).Print"(ptr @main.format, i64 100)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testdata/uint/in.go
+++ b/cl/_testdata/uint/in.go
@@ -3,10 +3,10 @@ package main
 
 import "github.com/goplus/lib/c"
 
-// CHECK: @"{{.*}}/uint.init$guard" = global i1 false, align 1
+// CHECK: @"main.init$guard" = global i1 false, align 1
 // CHECK: @0 = private unnamed_addr constant [11 x i8] c"Hello, %u\0A\00", align 1
 
-// CHECK-LABEL: define i32 @"{{.*}}.f"(i32 %0){{.*}} {
+// CHECK-LABEL: define i32 @main.f(i32 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = add i32 %0, 1
 // CHECK-NEXT:   ret i32 %1
@@ -16,9 +16,9 @@ func f(a c.Uint) c.Uint {
 	return a
 }
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 @"{{.*}}.f"(i32 100)
+// CHECK-NEXT:   %0 = call i32 @main.f(i32 100)
 // CHECK-NEXT:   %1 = call i32 (ptr, ...) @printf(ptr @0, i32 %0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testdata/untyped/in.go
+++ b/cl/_testdata/untyped/in.go
@@ -5,14 +5,14 @@ const c = 100
 
 var a float64 = 1
 
-// CHECK: @"{{.*}}/untyped.a" = global double 1.000000e+00, align 8
+// CHECK: @main.a = global double 1.000000e+00, align 8
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   br i1 false, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:{{.*}}
-// CHECK-NEXT:   store double 0.000000e+00, ptr @"{{.*}}.a", align 8
+// CHECK-NEXT:   store double 0.000000e+00, ptr @main.a, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:{{.*}}

--- a/cl/_testdata/utf8/in.go
+++ b/cl/_testdata/utf8/in.go
@@ -5,16 +5,16 @@ import (
 	"unicode/utf8"
 )
 
-// CHECK: @"{{.*}}.array" = global [8 x i8] c"\01\02\03\04\05\06\07\08", align 1
+// CHECK: @main.array = global [8 x i8] c"\01\02\03\04\05\06\07\08", align 1
 
-// CHECK-LABEL: define i8 @"{{.*}}.index"(i8 %0){{.*}} {
+// CHECK-LABEL: define i8 @main.index(i8 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = sext i8 %0 to i64
 // CHECK-NEXT:   %2 = icmp slt i64 %1, 0
 // CHECK-NEXT:   %3 = icmp uge i64 %1, 8
 // CHECK-NEXT:   %4 = or i1 %3, %2
-// CHECK-NEXT:   call void @"{{.*}}.CheckIndexRange"(i1 %4, {{.*}})
-// CHECK-NEXT:   %5 = getelementptr inbounds i8, ptr @"{{.*}}.array", i64 %1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %4, {{.*}})
+// CHECK-NEXT:   %5 = getelementptr inbounds i8, ptr @main.array, i64 %1
 // CHECK-NEXT:   %6 = load i8, ptr %5, align 1
 // CHECK-NEXT:   ret i8 %6
 // CHECK-NEXT: }
@@ -22,13 +22,13 @@ func index(n int8) uint8 {
 	return array[n]
 }
 
-// CHECK-LABEL: define void @"{{.*}}.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK:   call void @"unicode/utf8.init"()
 var array = [...]uint8{
 	1, 2, 3, 4, 5, 6, 7, 8,
 }
 
-// CHECK-LABEL: define void @"{{.*}}cl/_testdata/utf8.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -49,7 +49,7 @@ var array = [...]uint8{
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %8 = call i8 @"{{.*}}cl/_testdata/utf8.index"(i8 2)
+// CHECK-NEXT:   %8 = call i8 @main.index(i8 2)
 // CHECK-NEXT:   %9 = icmp eq i8 %8, 3
 // CHECK-NEXT:   call void @"{{.*}}runtime/internal/runtime.PrintBool"(i1 %9)
 // CHECK-NEXT:   call void @"{{.*}}runtime/internal/runtime.PrintByte"(i8 10)

--- a/cl/_testdata/vargs/in.go
+++ b/cl/_testdata/vargs/in.go
@@ -16,20 +16,20 @@ func test(a ...any) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/vargs.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testdata/vargs.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testdata/vargs.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/vargs.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 48)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %0, i64 0
@@ -50,11 +50,11 @@ func test(a ...any) {
 // CHECK-NEXT:   %10 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
 // CHECK-NEXT:   %11 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %10, i64 3, 1
 // CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %11, i64 3, 2
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testdata/vargs.test"(%"{{.*}}/runtime/internal/runtime.Slice" %12)
+// CHECK-NEXT:   call void @main.test(%"{{.*}}/runtime/internal/runtime.Slice" %12)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/vargs.test"(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
+// CHECK-LABEL: define void @main.test(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   br label %_llgo_1

--- a/cl/_testdata/varinit/in.go
+++ b/cl/_testdata/varinit/in.go
@@ -3,12 +3,12 @@ package main
 
 var a = 100
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i64, ptr @"{{.*}}.a", align 8
+// CHECK-NEXT:   %0 = load i64, ptr @main.a, align 8
 // CHECK-NEXT:   %1 = add i64 %0, 1
-// CHECK-NEXT:   store i64 %1, ptr @"{{.*}}.a", align 8
-// CHECK-NEXT:   %2 = load i64, ptr @"{{.*}}.a", align 8
+// CHECK-NEXT:   store i64 %1, ptr @main.a, align 8
+// CHECK-NEXT:   %2 = load i64, ptr @main.a, align 8
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -11,8 +11,9 @@ import (
 // CHECK: {{^}}@0 = private unnamed_addr constant [45 x i8] c"{{.*}}/cl/_testgo/abimethod.T", align 1{{$}}
 // CHECK: {{^}}@1 = private unnamed_addr constant [5 x i8] c"Demo1", align 1{{$}}
 // CHECK: {{^}}@5 = private unnamed_addr constant [3 x i8] c"int", align 1{{$}}
+// CHECK: {{^}}@7 = private unnamed_addr constant [6 x i8] c"main.T", align 1{{$}}
 // CHECK-NOT: {{^}}@{{[0-9]+}} = private unnamed_addr constant [5 x i8] c"demo3", align 1{{$}}
-// CHECK: {{^}}@11 = private unnamed_addr constant [49 x i8] c"{{.*}}/cl/_testgo/abimethod.demo3", align 1{{$}}
+// CHECK: {{^}}@11 = private unnamed_addr constant [10 x i8] c"main.demo3", align 1{{$}}
 // CHECK: {{^}}@13 = private unnamed_addr constant [20 x i8] c"testAnonymous1 error", align 1{{$}}
 // CHECK: {{^}}@15 = private unnamed_addr constant [20 x i8] c"testAnonymous2 error", align 1{{$}}
 // CHECK: {{^}}@17 = private unnamed_addr constant [20 x i8] c"testAnonymous3 error", align 1{{$}}
@@ -32,12 +33,12 @@ type T struct {
 	n int
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.T.Demo1(%main.T %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/abimethod.T", align 8
+// CHECK-NEXT:   %1 = alloca %main.T, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/abimethod.T" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.T %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.T, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
@@ -235,36 +236,36 @@ type I2 interface {
 	Demo2() int
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo1"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T).Demo1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 45 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 5 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %2)
+// CHECK-NEXT:   %2 = load %main.T, ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @main.T.Demo1(%main.T %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T).Demo2"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T).demo3"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/abimethod.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/abimethod.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @bytes.init()
 // CHECK-NEXT:   call void @fmt.init()
 // CHECK-NEXT:   call void @"sync/atomic.init"()
@@ -274,35 +275,35 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testGeneric"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testNamed1"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testNamed2"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testNamed3"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous1"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous2"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous3"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous4"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous5"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous6"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous7"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous8"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymousBuffer"()
+// CHECK-NEXT:   call void @main.testGeneric()
+// CHECK-NEXT:   call void @main.testNamed1()
+// CHECK-NEXT:   call void @main.testNamed2()
+// CHECK-NEXT:   call void @main.testNamed3()
+// CHECK-NEXT:   call void @main.testAnonymous1()
+// CHECK-NEXT:   call void @main.testAnonymous2()
+// CHECK-NEXT:   call void @main.testAnonymous3()
+// CHECK-NEXT:   call void @main.testAnonymous4()
+// CHECK-NEXT:   call void @main.testAnonymous5()
+// CHECK-NEXT:   call void @main.testAnonymous6()
+// CHECK-NEXT:   call void @main.testAnonymous7()
+// CHECK-NEXT:   call void @main.testAnonymous8()
+// CHECK-NEXT:   call void @main.testAnonymousBuffer()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous1"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymous1(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.T, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %4, align 8
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %5, 0
 // CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %6, ptr %0, 1
 // CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %7)
@@ -328,21 +329,21 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous2"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymous2(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.T, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %4, align 8
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store ptr %3, ptr %2, align 8
 // CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
@@ -368,19 +369,19 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous3"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymous3(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, align 8
+// CHECK-NEXT:   %0 = alloca { i64, %main.T }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.T, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store i64 100, ptr %3, align 8
-// CHECK-NEXT:   %4 = load { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, align 8
+// CHECK-NEXT:   %4 = load { i64, %main.T }, ptr %0, align 8
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { i64, %"{{.*}}/cl/_testgo/abimethod.T" } %4, ptr %5, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"{{.*}}/cl/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   store { i64, %main.T } %4, ptr %5, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %6, 0
 // CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %7, ptr %5, 1
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %8)
@@ -406,15 +407,15 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous4"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymous4(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.T, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store i64 100, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*{{.*}}/cl/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
 // CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
@@ -440,15 +441,15 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous5"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymous5(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.T, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store i64 100, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"*{{.*}}/cl/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
 // CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
@@ -474,21 +475,21 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous6"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymous6(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.T, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %4, align 8
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store ptr %3, ptr %2, align 8
 // CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
@@ -514,21 +515,21 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous7"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymous7(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.T, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %4, align 8
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store ptr %3, ptr %2, align 8
 // CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw", ptr @"{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
@@ -574,21 +575,21 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous8"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymous8(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.T, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %4, align 8
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store ptr %3, ptr %2, align 8
 // CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA", ptr @"{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/abimethod.iface${{[-A-Za-z0-9_]+}}", ptr @"{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
@@ -654,7 +655,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymousBuffer"(){{.*}} {
+// CHECK-LABEL: define void @main.testAnonymousBuffer(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
@@ -662,7 +663,7 @@ type I2 interface {
 // CHECK-NEXT:   %3 = call ptr @bytes.NewBufferString(%"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 5 })
 // CHECK-NEXT:   store i64 10, ptr %1, align 8
 // CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*{{.*}}/cl/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY")
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*{{.*}}/cl/_testgo/abimethod.struct${{[-A-Za-z0-9_]+}}")
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
 // CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
@@ -689,13 +690,13 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testGeneric"(){{.*}} {
+// CHECK-LABEL: define void @main.testGeneric(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds", ptr @"*_llgo_{{.*}}/cl/_testgo/abimethod.Pointer[any]")
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.Pointer[any]")
 // CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %1, 0
 // CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %2, ptr %0, 1
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/cl/_testgo/abimethod.testGeneric$1"()
+// CHECK-NEXT:   %4 = call ptr @"main.testGeneric$1"()
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
 // CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 4
@@ -740,7 +741,7 @@ type I2 interface {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/abimethod.testGeneric$1"(){{.*}} {
+// CHECK-LABEL: define ptr @"main.testGeneric$1"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
@@ -750,12 +751,12 @@ type I2 interface {
 // CHECK-NEXT:   ret ptr %0
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testNamed1"(){{.*}} {
+// CHECK-LABEL: define void @main.testNamed1(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*_llgo_{{.*}}/cl/_testgo/abimethod.T")
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T")
 // CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
@@ -781,16 +782,16 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testNamed2"(){{.*}} {
+// CHECK-LABEL: define void @main.testNamed2(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/abimethod.T", align 8
+// CHECK-NEXT:   %0 = alloca %main.T, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %1, align 8
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, align 8
+// CHECK-NEXT:   %2 = load %main.T, ptr %0, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/abimethod.T" %2, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"_llgo_{{.*}}/cl/_testgo/abimethod.T")
+// CHECK-NEXT:   store %main.T %2, ptr %3, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.T)
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %3, 1
 // CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
@@ -816,12 +817,12 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testNamed3"(){{.*}} {
+// CHECK-LABEL: define void @main.testNamed3(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"*_llgo_{{.*}}/cl/_testgo/abimethod.T")
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T")
 // CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
@@ -847,7 +848,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *main.T}.Demo1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -856,28 +857,28 @@ type I2 interface {
 // CHECK-NEXT:   %4 = icmp eq ptr %1, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %4)
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %2)
-// CHECK-NEXT:   %6 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %5, align 8
-// CHECK-NEXT:   %7 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %6)
+// CHECK-NEXT:   %6 = load %main.T, ptr %5, align 8
+// CHECK-NEXT:   %7 = call i64 @main.T.Demo1(%main.T %6)
 // CHECK-NEXT:   ret i64 %7
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *main.T}.Demo2"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %2)
+// CHECK-NEXT:   %3 = call i64 @"main.(*T).Demo2"(ptr %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *main.T}.demo3"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %2)
+// CHECK-NEXT:   %3 = call i64 @"main.(*T).demo3"(ptr %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *main.T}.Demo1"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -885,30 +886,30 @@ type I2 interface {
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %3)
-// CHECK-NEXT:   %5 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %4, align 8
-// CHECK-NEXT:   %6 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %5)
+// CHECK-NEXT:   %5 = load %main.T, ptr %4, align 8
+// CHECK-NEXT:   %6 = call i64 @main.T.Demo1(%main.T %5)
 // CHECK-NEXT:   ret i64 %6
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *main.T}.Demo2"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %3)
+// CHECK-NEXT:   %4 = call i64 @"main.(*T).Demo2"(ptr %3)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *main.T}.demo3"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %3)
+// CHECK-NEXT:   %4 = call i64 @"main.(*T).demo3"(ptr %3)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
@@ -918,63 +919,63 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.T.Demo1"(ptr %0, %"{{.*}}/cl/_testgo/abimethod.T" %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.T.Demo1(ptr %0, %main.T %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %1)
+// CHECK-NEXT:   %2 = tail call i64 @main.T.Demo1(%main.T %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.(*T).Demo1"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T).Demo1"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo1"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T).Demo1"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T).Demo2"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T).Demo2"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T).demo3"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T).demo3"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *main.T}.Demo1"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.struct{m int; *main.T}.Demo1"({ i64, ptr } %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *main.T}.Demo2"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.struct{m int; *main.T}.Demo2"({ i64, ptr } %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *main.T}.demo3"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.struct{m int; *main.T}.demo3"({ i64, ptr } %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *main.T}.Demo1"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; *main.T}.Demo1"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *main.T}.Demo2"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; *main.T}.Demo2"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *main.T}.demo3"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; *main.T}.demo3"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
@@ -984,67 +985,67 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"({ i64, %"{{.*}}/cl/_testgo/abimethod.T" } %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; main.T}.Demo1"({ i64, %main.T } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, align 8
+// CHECK-NEXT:   %1 = alloca { i64, %main.T }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store { i64, %"{{.*}}/cl/_testgo/abimethod.T" } %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %1, i32 0, i32 1
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %3)
+// CHECK-NEXT:   store { i64, %main.T } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %main.T }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load %main.T, ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @main.T.Demo1(%main.T %3)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; main.T}.Demo1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %1)
-// CHECK-NEXT:   %4 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, align 8
-// CHECK-NEXT:   %5 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %4)
+// CHECK-NEXT:   %4 = load %main.T, ptr %3, align 8
+// CHECK-NEXT:   %5 = call i64 @main.T.Demo1(%main.T %4)
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; main.T}.Demo2"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %1)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = call i64 @"main.(*T).Demo2"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; main.T}.demo3"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %1)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %main.T }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = call i64 @"main.(*T).demo3"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; main.T}.Demo1"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; main.T}.Demo1"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; main.T}.Demo2"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; main.T}.Demo2"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; main.T}.demo3"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; main.T}.demo3"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0, { i64, %"{{.*}}/cl/_testgo/abimethod.T" } %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; main.T}.Demo1"(ptr %0, { i64, %main.T } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"({ i64, %"{{.*}}/cl/_testgo/abimethod.T" } %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.struct{m int; main.T}.Demo1"({ i64, %main.T } %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *bytes.Buffer}.Available"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1052,7 +1053,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"main.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1060,7 +1061,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"main.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1068,7 +1069,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *bytes.Buffer}.Cap"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1076,7 +1077,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"main.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1084,7 +1085,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *bytes.Buffer}.Len"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1092,7 +1093,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"main.*struct{m int; *bytes.Buffer}.Next"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1100,7 +1101,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1112,7 +1113,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0){{.*}} {
+// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1124,7 +1125,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %7
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1136,7 +1137,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1148,7 +1149,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0){{.*}} {
+// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1162,7 +1163,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1174,7 +1175,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.*struct{m int; *bytes.Buffer}.Reset"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1182,7 +1183,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.*struct{m int; *bytes.Buffer}.String"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1190,7 +1191,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"main.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1198,7 +1199,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1206,7 +1207,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1214,7 +1215,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.Write"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1226,7 +1227,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1234,7 +1235,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, i32 %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1246,7 +1247,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1258,7 +1259,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1270,7 +1271,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i1 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty"(ptr %0){{.*}} {
+// CHECK-LABEL: define i1 @"main.*struct{m int; *bytes.Buffer}.empty"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1278,7 +1279,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1286,7 +1287,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1298,7 +1299,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i1 } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define { i64, i1 } @"main.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1310,7 +1311,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, i1 } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1321,7 +1322,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"main.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1332,7 +1333,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"main.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1343,7 +1344,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1354,7 +1355,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"main.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1365,7 +1366,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1376,7 +1377,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"main.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1387,7 +1388,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1402,7 +1403,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1417,7 +1418,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1432,7 +1433,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1447,7 +1448,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1464,7 +1465,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %10
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1479,7 +1480,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define void @"main.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1490,7 +1491,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1501,7 +1502,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"main.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1512,7 +1513,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1523,7 +1524,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1534,7 +1535,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1549,7 +1550,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1560,7 +1561,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %0, i32 %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1575,7 +1576,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1590,7 +1591,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1605,7 +1606,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i1 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i1 @"main.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
@@ -1616,7 +1617,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1627,7 +1628,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1642,7 +1643,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i1 } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define { i64, i1 } @"main.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
@@ -1825,344 +1826,344 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, i1 } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Available"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.main.struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"main.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Bytes"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"main.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Cap"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Grow"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %1, i64 %2)
+// CHECK-NEXT:   tail call void @"main.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %1, i64 %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Len"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Next"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"main.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %1, i64 %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Read"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.ReadByte"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %1)
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %1, i8 %2)
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.ReadRune"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %1)
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.ReadString"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %1, i8 %2)
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Reset"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %1)
+// CHECK-NEXT:   tail call void @"main.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.main.struct{m int; *bytes.Buffer}.String"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"main.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Truncate"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %1, i64 %2)
+// CHECK-NEXT:   tail call void @"main.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %1, i64 %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.Write"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %1, i8 %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, { i64, ptr } %1, i32 %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, { i64, ptr } %1, i32 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %1, i32 %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %1, i32 %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.String" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.WriteString"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.String" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.String" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.String" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, { i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"(ptr %0, { i64, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.empty"(ptr %0, { i64, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i1 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %1)
+// CHECK-NEXT:   %2 = tail call i1 @"main.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %1)
 // CHECK-NEXT:   ret i1 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.struct{m int; *bytes.Buffer}.grow"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.readSlice"(ptr %0, { i64, ptr } %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %1, i8 %2)
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, i1 } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, i1 } @"__llgo_stub.main.struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, { i64, ptr } %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, i1 } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call { i64, i1 } @"main.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %1, i64 %2)
 // CHECK-NEXT:   ret { i64, i1 } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Available"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; *bytes.Buffer}.Available"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"main.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"main.*struct{m int; *bytes.Buffer}.Bytes"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Cap"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; *bytes.Buffer}.Cap"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow"(ptr %1, i64 %2)
+// CHECK-NEXT:   tail call void @"main.*struct{m int; *bytes.Buffer}.Grow"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Len"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.*struct{m int; *bytes.Buffer}.Len"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Next"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next"(ptr %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.Slice" @"main.*struct{m int; *bytes.Buffer}.Next"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Read"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.Read"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %1)
+// CHECK-NEXT:   %2 = tail call { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %1)
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, ptr %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, ptr %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %1, i8 %2)
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %1)
+// CHECK-NEXT:   %2 = tail call { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %1)
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, ptr %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, ptr %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString"(ptr %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.ReadString"(ptr %1, i8 %2)
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Reset"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.*struct{m int; *bytes.Buffer}.Reset"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.String"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"main.*struct{m int; *bytes.Buffer}.String"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate"(ptr %1, i64 %2)
+// CHECK-NEXT:   tail call void @"main.*struct{m int; *bytes.Buffer}.Truncate"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.Write"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.Write"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, ptr %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, ptr %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %1, i8 %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, ptr %1, i32 %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, ptr %1, i32 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %1, i32 %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %1, i32 %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.String" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.String" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString"(ptr %1, %"{{.*}}/runtime/internal/runtime.String" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.WriteString"(ptr %1, %"{{.*}}/runtime/internal/runtime.String" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.empty"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i1 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i1 @"main.*struct{m int; *bytes.Buffer}.empty"(ptr %1)
 // CHECK-NEXT:   ret i1 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.grow"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow"(ptr %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.*struct{m int; *bytes.Buffer}.grow"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, ptr %1, i8 %2){{.*}} {
+// CHECK-LABEL: define linkonce { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, ptr %1, i8 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice"(ptr %1, i8 %2)
+// CHECK-NEXT:   %3 = tail call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"main.*struct{m int; *bytes.Buffer}.readSlice"(ptr %1, i8 %2)
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, i1 } @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, i1 } @"__llgo_stub.main.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, i1 } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call { i64, i1 } @"main.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret { i64, i1 } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce ptr @"{{.*}}/cl/_testgo/abimethod.(*Pointer[any]).Load"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce ptr @"main.(*Pointer[any]).Load"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.Pointer[any]", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load atomic ptr, ptr %2 seq_cst, align 8
 // CHECK-NEXT:   ret ptr %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testgo/abimethod.(*Pointer[any]).Store"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.(*Pointer[any]).Store"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"main.Pointer[any]", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store atomic ptr %1, ptr %3 seq_cst, align 8
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -2173,14 +2174,14 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce ptr @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.(*Pointer[any]).Load"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce ptr @"__llgo_stub.main.(*Pointer[any]).Load"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call ptr @"{{.*}}/cl/_testgo/abimethod.(*Pointer[any]).Load"(ptr %1)
+// CHECK-NEXT:   %2 = tail call ptr @"main.(*Pointer[any]).Load"(ptr %1)
 // CHECK-NEXT:   ret ptr %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/abimethod.(*Pointer[any]).Store"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.(*Pointer[any]).Store"(ptr %0, ptr %1, ptr %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/abimethod.(*Pointer[any]).Store"(ptr %1, ptr %2)
+// CHECK-NEXT:   tail call void @"main.(*Pointer[any]).Store"(ptr %1, ptr %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testgo/alias/in.go
+++ b/cl/_testgo/alias/in.go
@@ -8,17 +8,17 @@ type Point struct {
 
 type MyPoint = Point
 
-// CHECK-LABEL: define void @"{{.*}}alias.(*Point).Move"(ptr %0, double %1, double %2){{.*}} {
+// CHECK-LABEL: define void @"main.(*Point).Move"(ptr %0, double %1, double %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}alias.Point", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %4 = load double, ptr %3, align 8
 // CHECK-NEXT:   %5 = fadd double %4, %1
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}alias.Point", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store double %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}alias.Point", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %8 = load double, ptr %7, align 8
 // CHECK-NEXT:   %9 = fadd double %8, %2
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}alias.Point", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store double %9, ptr %10, align 8
 // CHECK-NEXT:   ret void
 func (p *MyPoint) Move(dx, dy float64) {
@@ -26,17 +26,17 @@ func (p *MyPoint) Move(dx, dy float64) {
 	p.y += dy
 }
 
-// CHECK-LABEL: define void @"{{.*}}alias.(*Point).Scale"(ptr %0, double %1){{.*}} {
+// CHECK-LABEL: define void @"main.(*Point).Scale"(ptr %0, double %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}alias.Point", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load double, ptr %2, align 8
 // CHECK-NEXT:   %4 = fmul double %3, %1
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}alias.Point", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store double %4, ptr %5, align 8
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}alias.Point", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %7 = load double, ptr %6, align 8
 // CHECK-NEXT:   %8 = fmul double %7, %1
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}alias.Point", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store double %8, ptr %9, align 8
 // CHECK-NEXT:   ret void
 func (p *Point) Scale(factor float64) {
@@ -44,11 +44,11 @@ func (p *Point) Scale(factor float64) {
 	p.y *= factor
 }
 
-// CHECK-LABEL: define void @"{{.*}}alias.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 16)
-	// CHECK: call void @"{{.*}}alias.(*Point).Scale"(ptr %0, double 2.000000e+00)
-	// CHECK: call void @"{{.*}}alias.(*Point).Move"(ptr %0, double 3.000000e+00, double 4.000000e+00)
+	// CHECK: call void @"main.(*Point).Scale"(ptr %0, double 2.000000e+00)
+	// CHECK: call void @"main.(*Point).Move"(ptr %0, double 3.000000e+00, double 4.000000e+00)
 	// CHECK: call void @"{{.*}}PrintFloat"(double %4)
 	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 32)
 	// CHECK-NEXT: call void @"{{.*}}PrintFloat"(double %6)

--- a/cl/_testgo/allocinloop/in.go
+++ b/cl/_testgo/allocinloop/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define i64 @"{{.*}}allocinloop.Foo"(%"{{.*}}String" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.Foo(%"{{.*}}String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}String" %0, 1
 // CHECK-NEXT:   ret i64 %1
@@ -9,7 +9,7 @@ func Foo(s string) int {
 	return len(s)
 }
 
-// CHECK-LABEL: define void @"{{.*}}allocinloop.Test"(){{.*}} {
+// CHECK-LABEL: define void @main.Test(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -20,7 +20,7 @@ func Foo(s string) int {
 // CHECK-NEXT:   br i1 %2, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}allocinloop.Foo"(%"{{.*}}String" { ptr @0, i64 5 })
+// CHECK-NEXT:   %3 = call i64 @main.Foo(%"{{.*}}String" { ptr @0, i64 5 })
 // CHECK-NEXT:   %4 = add i64 %0, %3
 // CHECK-NEXT:   %5 = add i64 %1, 1
 // CHECK-NEXT:   br label %_llgo_1
@@ -37,9 +37,9 @@ func Test() {
 	println(j)
 }
 
-// CHECK-LABEL: define void @"{{.*}}allocinloop.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}allocinloop.Test"()
+// CHECK-NEXT:   call void @main.Test()
 // CHECK-NEXT:   ret void
 func main() {
 	Test()

--- a/cl/_testgo/cgobasic/cgobasic.go
+++ b/cl/_testgo/cgobasic/cgobasic.go
@@ -12,90 +12,90 @@ import (
 	"unsafe"
 )
 
-// CHECK-LABEL: define double @"{{.*}}/cl/_testgo/cgobasic._Cfunc_cos"(double %0){{.*}} {
+// CHECK-LABEL: define double @main._Cfunc_cos(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_cos", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_cos, align 8
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call double %3(double %0)
 // CHECK-NEXT:   ret double %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/cgobasic._Cfunc_free"(ptr %0){{.*}} {
+// CHECK-LABEL: define [0 x i8] @main._Cfunc_free(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_free", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_free, align 8
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call [0 x i8] %3(ptr %0)
 // CHECK-NEXT:   ret [0 x i8] %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define double @"{{.*}}/cl/_testgo/cgobasic._Cfunc_log"(double %0){{.*}} {
+// CHECK-LABEL: define double @main._Cfunc_log(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_log", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_log, align 8
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call double %3(double %0)
 // CHECK-NEXT:   ret double %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgobasic._Cfunc_puts"(ptr %0){{.*}} {
+// CHECK-LABEL: define i32 @main._Cfunc_puts(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_puts", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_puts, align 8
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call i32 %3(ptr %0)
 // CHECK-NEXT:   ret i32 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define double @"{{.*}}/cl/_testgo/cgobasic._Cfunc_sin"(double %0){{.*}} {
+// CHECK-LABEL: define double @main._Cfunc_sin(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_sin", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_sin, align 8
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call double %3(double %0)
 // CHECK-NEXT:   ret double %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define double @"{{.*}}/cl/_testgo/cgobasic._Cfunc_sqrt"(double %0){{.*}} {
+// CHECK-LABEL: define double @main._Cfunc_sqrt(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_sqrt", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_sqrt, align 8
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call double %3(double %0)
 // CHECK-NEXT:   ret double %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgobasic.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/cgobasic.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/cgobasic.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @syscall.init()
 // CHECK-NEXT:   call void @fmt.init()
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_cos, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_cos", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_free, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_free", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_log, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_log", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_puts, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_puts", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_sin, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_sin", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_sqrt, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc_sqrt", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc__Cmalloc, ptr @"{{.*}}/cl/_testgo/cgobasic._cgo_{{.*}}_Cfunc__Cmalloc", align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_cos, ptr @main._cgo_{{.*}}_Cfunc_cos, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_free, ptr @main._cgo_{{.*}}_Cfunc_free, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_log, ptr @main._cgo_{{.*}}_Cfunc_log, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_puts, ptr @main._cgo_{{.*}}_Cfunc_puts, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_sin, ptr @main._cgo_{{.*}}_Cfunc_sin, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_sqrt, ptr @main._cgo_{{.*}}_Cfunc_sqrt, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc__Cmalloc, ptr @main._cgo_{{.*}}_Cfunc__Cmalloc, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgobasic.main"(){{.*}} {
-// CHECK:   %{{.*}} = call i32 @"{{.*}}/cl/_testgo/cgobasic._Cfunc_puts"(ptr %{{.*}})
-// CHECK:   %{{.*}} = call double @"{{.*}}/cl/_testgo/cgobasic._Cfunc_sqrt"(double 2.000000e+00)
-// CHECK:   %{{.*}} = call double @"{{.*}}/cl/_testgo/cgobasic._Cfunc_sin"(double 2.000000e+00)
-// CHECK:   %{{.*}} = call double @"{{.*}}/cl/_testgo/cgobasic._Cfunc_cos"(double 2.000000e+00)
-// CHECK:   %{{.*}} = call double @"{{.*}}/cl/_testgo/cgobasic._Cfunc_log"(double 2.000000e+00)
-// CHECK:   %{{.*}} = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/cgobasic.main$3", ptr undef }, ptr %{{.*}}, 1
-// CHECK:   %{{.*}} = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/cgobasic.main$4", ptr undef }, ptr %{{.*}}, 1
+// CHECK-LABEL: define void @main.main(){{.*}} {
+// CHECK:   %{{.*}} = call i32 @main._Cfunc_puts(ptr %{{.*}})
+// CHECK:   %{{.*}} = call double @main._Cfunc_sqrt(double 2.000000e+00)
+// CHECK:   %{{.*}} = call double @main._Cfunc_sin(double 2.000000e+00)
+// CHECK:   %{{.*}} = call double @main._Cfunc_cos(double 2.000000e+00)
+// CHECK:   %{{.*}} = call double @main._Cfunc_log(double 2.000000e+00)
+// CHECK:   %{{.*}} = insertvalue { ptr, ptr } { ptr @"main.main$3", ptr undef }, ptr %{{.*}}, 1
+// CHECK:   %{{.*}} = insertvalue { ptr, ptr } { ptr @"main.main$4", ptr undef }, ptr %{{.*}}, 1
 func main() {
 	// C.CString example
 	cstr := C.CString("Hello, World!")
@@ -139,7 +139,7 @@ func main() {
 	C.free(cbytes)
 }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/cgobasic.main$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define ptr @"main.main$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
@@ -151,7 +151,7 @@ func main() {
 // CHECK-NEXT:   ret ptr %6
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/cgobasic.main$2"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"main.main$2"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
@@ -161,22 +161,22 @@ func main() {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgobasic.main$3"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.main$3"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_Pointer, ptr undef }, ptr %3, 1
-// CHECK-NEXT:   %5 = call [0 x i8] @"{{.*}}/cl/_testgo/cgobasic._Cfunc_free"(ptr %3)
+// CHECK-NEXT:   %5 = call [0 x i8] @main._Cfunc_free(ptr %3)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgobasic.main$4"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.main$4"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_Pointer, ptr undef }, ptr %3, 1
-// CHECK-NEXT:   %5 = call [0 x i8] @"{{.*}}/cl/_testgo/cgobasic._Cfunc_free"(ptr %3)
+// CHECK-NEXT:   %5 = call [0 x i8] @main._Cfunc_free(ptr %3)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testgo/cgocfiles/cgocfiles.go
+++ b/cl/_testgo/cgocfiles/cgocfiles.go
@@ -7,53 +7,53 @@ package main
 import "C"
 import "fmt"
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgocfiles._Cfunc_test_structs"(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4){{.*}} {
+// CHECK-LABEL: define i32 @main._Cfunc_test_structs(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %6 = load ptr, ptr @"{{.*}}/cl/_testgo/cgocfiles._cgo_{{.*}}_Cfunc_test_structs", align 8
+// CHECK-NEXT:   %6 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_test_structs, align 8
 // CHECK-NEXT:   %7 = load ptr, ptr %6, align 8
 // CHECK-NEXT:   %8 = call i32 %7(ptr %0, ptr %1, ptr %2, ptr %3, ptr %4)
 // CHECK-NEXT:   ret i32 %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgocfiles.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 4)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___3", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main._Ctype_struct___3, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i32 1, ptr %1, align 4
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___4", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___4", ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %main._Ctype_struct___4, ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main._Ctype_struct___4, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   store i32 1, ptr %3, align 4
 // CHECK-NEXT:   store i32 2, ptr %4, align 4
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 12)
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___0", ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___0", ptr %5, i32 0, i32 1
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___0", ptr %5, i32 0, i32 2
+// CHECK-NEXT:   %6 = getelementptr inbounds %main._Ctype_struct___0, ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %main._Ctype_struct___0, ptr %5, i32 0, i32 1
+// CHECK-NEXT:   %8 = getelementptr inbounds %main._Ctype_struct___0, ptr %5, i32 0, i32 2
 // CHECK-NEXT:   store i32 1, ptr %6, align 4
 // CHECK-NEXT:   store i32 2, ptr %7, align 4
 // CHECK-NEXT:   store i32 3, ptr %8, align 4
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___1", ptr %9, i32 0, i32 0
-// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___1", ptr %9, i32 0, i32 1
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___1", ptr %9, i32 0, i32 2
-// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___1", ptr %9, i32 0, i32 3
+// CHECK-NEXT:   %10 = getelementptr inbounds %main._Ctype_struct___1, ptr %9, i32 0, i32 0
+// CHECK-NEXT:   %11 = getelementptr inbounds %main._Ctype_struct___1, ptr %9, i32 0, i32 1
+// CHECK-NEXT:   %12 = getelementptr inbounds %main._Ctype_struct___1, ptr %9, i32 0, i32 2
+// CHECK-NEXT:   %13 = getelementptr inbounds %main._Ctype_struct___1, ptr %9, i32 0, i32 3
 // CHECK-NEXT:   store i32 1, ptr %10, align 4
 // CHECK-NEXT:   store i32 2, ptr %11, align 4
 // CHECK-NEXT:   store i32 3, ptr %12, align 4
 // CHECK-NEXT:   store i32 4, ptr %13, align 4
 // CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 20)
-// CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___2", ptr %14, i32 0, i32 0
-// CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___2", ptr %14, i32 0, i32 1
-// CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___2", ptr %14, i32 0, i32 2
-// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___2", ptr %14, i32 0, i32 3
-// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testgo/cgocfiles._Ctype_struct___2", ptr %14, i32 0, i32 4
+// CHECK-NEXT:   %15 = getelementptr inbounds %main._Ctype_struct___2, ptr %14, i32 0, i32 0
+// CHECK-NEXT:   %16 = getelementptr inbounds %main._Ctype_struct___2, ptr %14, i32 0, i32 1
+// CHECK-NEXT:   %17 = getelementptr inbounds %main._Ctype_struct___2, ptr %14, i32 0, i32 2
+// CHECK-NEXT:   %18 = getelementptr inbounds %main._Ctype_struct___2, ptr %14, i32 0, i32 3
+// CHECK-NEXT:   %19 = getelementptr inbounds %main._Ctype_struct___2, ptr %14, i32 0, i32 4
 // CHECK-NEXT:   store i32 1, ptr %15, align 4
 // CHECK-NEXT:   store i32 2, ptr %16, align 4
 // CHECK-NEXT:   store i32 3, ptr %17, align 4
 // CHECK-NEXT:   store i32 4, ptr %18, align 4
 // CHECK-NEXT:   store i32 5, ptr %19, align 4
-// CHECK-NEXT:   %20 = call i32 @"{{.*}}/cl/_testgo/cgocfiles._Cfunc_test_structs"(ptr %0, ptr %2, ptr %5, ptr %9, ptr %14)
+// CHECK-NEXT:   %20 = call i32 @main._Cfunc_test_structs(ptr %0, ptr %2, ptr %5, ptr %9, ptr %14)
 func main() {
 	r := C.test_structs(&C.s4{a: 1}, &C.s8{a: 1, b: 2}, &C.s12{a: 1, b: 2, c: 3}, &C.s16{a: 1, b: 2, c: 3, d: 4}, &C.s20{a: 1, b: 2, c: 3, d: 4, e: 5})
 	fmt.Println(r)

--- a/cl/_testgo/cgodefer/cgodefer.go
+++ b/cl/_testgo/cgodefer/cgodefer.go
@@ -6,16 +6,16 @@ package main
 */
 import "C"
 
-// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/cgodefer._Cfunc_free"(ptr %0){{.*}} {
+// CHECK-LABEL: define [0 x i8] @main._Cfunc_free(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testgo/cgodefer._cgo_{{.*}}_Cfunc_free", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_free, align 8
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call [0 x i8] %3(ptr %0)
 // CHECK-NEXT:   ret [0 x i8] %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgodefer.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   %1 = call ptr @malloc(i64 1024)
@@ -23,7 +23,7 @@ import "C"
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %3 = getelementptr inbounds { ptr }, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/cgodefer.main$1", ptr undef }, ptr %2, 1
+// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %2, 1
 // CHECK-NEXT:   %5 = extractvalue { ptr, ptr } %4, 1
 // CHECK-NEXT:   %6 = extractvalue { ptr, ptr } %4, 0
 // CHECK-NEXT:   %7 = call { ptr, ptr } %6(ptr %5)
@@ -37,7 +37,7 @@ import "C"
 // CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %10, i32 0, i32 2
 // CHECK-NEXT:   store ptr %8, ptr %13, align 8
 // CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %10, i32 0, i32 3
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgodefer.main", %_llgo_2), ptr %14, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_2), ptr %14, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %10)
 // CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %10, i32 0, i32 1
 // CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %10, i32 0, i32 3
@@ -52,7 +52,7 @@ import "C"
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgodefer.main", %_llgo_3), ptr %16, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_3), ptr %16, align 8
 // CHECK-NEXT:   %21 = load i64, ptr %15, align 8
 // CHECK-NEXT:   %22 = load ptr, ptr %18, align 8
 // CHECK-NEXT:   %23 = icmp ne ptr %22, null
@@ -72,11 +72,11 @@ import "C"
 // CHECK-NEXT:   %28 = getelementptr inbounds { ptr, i64, { ptr, ptr } }, ptr %25, i32 0, i32 2
 // CHECK-NEXT:   store { ptr, ptr } %7, ptr %28, align 8
 // CHECK-NEXT:   store ptr %25, ptr %18, align 8
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgodefer.main", %_llgo_6), ptr %17, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_6), ptr %17, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgodefer.main", %_llgo_3), ptr %17, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_3), ptr %17, align 8
 // CHECK-NEXT:   %29 = load ptr, ptr %16, align 8
 // CHECK-NEXT:   indirectbr ptr %29, [label %_llgo_3, label %_llgo_2]
 // CHECK-EMPTY:
@@ -103,7 +103,7 @@ import "C"
 // CHECK-NEXT:   indirectbr ptr %38, [label %_llgo_3, label %_llgo_6]
 // CHECK-NEXT: }
 func main() {
-	// CHECK-LABEL: define { ptr, ptr } @"{{.*}}/cl/_testgo/cgodefer.main$1"(ptr %0){{.*}} {
+	// CHECK-LABEL: define { ptr, ptr } @"main.main$1"(ptr %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 	// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
@@ -113,11 +113,11 @@ func main() {
 	// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 	// CHECK-NEXT:   %6 = getelementptr inbounds { ptr }, ptr %5, i32 0, i32 0
 	// CHECK-NEXT:   store ptr %1, ptr %6, align 8
-	// CHECK-NEXT:   %7 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/cgodefer.main$1$1", ptr undef }, ptr %5, 1
+	// CHECK-NEXT:   %7 = insertvalue { ptr, ptr } { ptr @"main.main$1$1", ptr undef }, ptr %5, 1
 	// CHECK-NEXT:   ret { ptr, ptr } %7
 	// CHECK-NEXT: }
 	p := C.malloc(1024)
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgodefer.main$1$1"(ptr %0){{.*}} {
+	// CHECK-LABEL: define void @"main.main$1$1"(ptr %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 	// CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
@@ -125,7 +125,7 @@ func main() {
 	// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_Pointer, ptr undef }, ptr %3, 1
 	// CHECK-NEXT:   %5 = extractvalue { ptr } %1, 0
 	// CHECK-NEXT:   %6 = load ptr, ptr %5, align 8
-	// CHECK-NEXT:   %7 = call [0 x i8] @"{{.*}}/cl/_testgo/cgodefer._Cfunc_free"(ptr %6)
+	// CHECK-NEXT:   %7 = call [0 x i8] @main._Cfunc_free(ptr %6)
 	// CHECK-NEXT:   ret void
 	// CHECK-NEXT: }
 	defer C.free(p)

--- a/cl/_testgo/cgomacro/cgomacro.go
+++ b/cl/_testgo/cgomacro/cgomacro.go
@@ -18,108 +18,108 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_PyObject_Print"(ptr %0, ptr %1, i32 %2){{.*}} {
+// CHECK-LABEL: define i32 @main._Cfunc_PyObject_Print(ptr %0, ptr %1, i32 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_PyObject_Print", align 8
+// CHECK-NEXT:   %4 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_PyObject_Print, align 8
 // CHECK-NEXT:   %5 = load ptr, ptr %4, align 8
 // CHECK-NEXT:   %6 = call i32 %5(ptr %0, ptr %1, i32 %2)
 // CHECK-NEXT:   ret i32 %6
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/cgomacro._Cfunc_Py_Finalize"(){{.*}} {
+// CHECK-LABEL: define [0 x i8] @main._Cfunc_Py_Finalize(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_Py_Finalize", align 8
+// CHECK-NEXT:   %0 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_Py_Finalize, align 8
 // CHECK-NEXT:   %1 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %2 = call [0 x i8] %1()
 // CHECK-NEXT:   ret [0 x i8] %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/cgomacro._Cfunc_Py_Initialize"(){{.*}} {
+// CHECK-LABEL: define [0 x i8] @main._Cfunc_Py_Initialize(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_Py_Initialize", align 8
+// CHECK-NEXT:   %0 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_Py_Initialize, align 8
 // CHECK-NEXT:   %1 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %2 = call [0 x i8] %1()
 // CHECK-NEXT:   ret [0 x i8] %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_fputs"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define i32 @main._Cfunc_fputs(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %3 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_fputs", align 8
+// CHECK-NEXT:   %3 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_fputs, align 8
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
 // CHECK-NEXT:   %5 = call i32 %4(ptr %0, ptr %1)
 // CHECK-NEXT:   ret i32 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/cgomacro._Cfunc_test_stdout"(){{.*}} {
+// CHECK-LABEL: define [0 x i8] @main._Cfunc_test_stdout(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_test_stdout", align 8
+// CHECK-NEXT:   %0 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_test_stdout, align 8
 // CHECK-NEXT:   %1 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %2 = call [0 x i8] %1()
 // CHECK-NEXT:   ret [0 x i8] %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_Py_False"(){{.*}} {
+// CHECK-LABEL: define ptr @main._Cmacro_Py_False(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cmacro_Py_False", align 8
+// CHECK-NEXT:   %1 = load ptr, ptr @main._cgo_{{.*}}_Cmacro_Py_False, align 8
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
 // CHECK-NEXT:   ret ptr %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_Py_None"(){{.*}} {
+// CHECK-LABEL: define ptr @main._Cmacro_Py_None(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cmacro_Py_None", align 8
+// CHECK-NEXT:   %1 = load ptr, ptr @main._cgo_{{.*}}_Cmacro_Py_None, align 8
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
 // CHECK-NEXT:   ret ptr %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_Py_True"(){{.*}} {
+// CHECK-LABEL: define ptr @main._Cmacro_Py_True(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cmacro_Py_True", align 8
+// CHECK-NEXT:   %1 = load ptr, ptr @main._cgo_{{.*}}_Cmacro_Py_True, align 8
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
 // CHECK-NEXT:   ret ptr %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_stdout"(){{.*}} {
+// CHECK-LABEL: define ptr @main._Cmacro_stdout(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = load ptr, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cmacro_stdout", align 8
+// CHECK-NEXT:   %1 = load ptr, ptr @main._cgo_{{.*}}_Cmacro_stdout, align 8
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
 // CHECK-NEXT:   ret ptr %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgomacro.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/cgomacro.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/cgomacro.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @syscall.init()
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_PyObject_Print, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_PyObject_Print", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cmacro_Py_False, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cmacro_Py_False", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_Py_Finalize, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_Py_Finalize", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_Py_Initialize, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_Py_Initialize", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cmacro_Py_None, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cmacro_Py_None", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cmacro_Py_True, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cmacro_Py_True", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_fputs, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_fputs", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cmacro_stdout, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cmacro_stdout", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_test_stdout, ptr @"{{.*}}/cl/_testgo/cgomacro._cgo_{{.*}}_Cfunc_test_stdout", align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_PyObject_Print, ptr @main._cgo_{{.*}}_Cfunc_PyObject_Print, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cmacro_Py_False, ptr @main._cgo_{{.*}}_Cmacro_Py_False, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_Py_Finalize, ptr @main._cgo_{{.*}}_Cfunc_Py_Finalize, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_Py_Initialize, ptr @main._cgo_{{.*}}_Cfunc_Py_Initialize, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cmacro_Py_None, ptr @main._cgo_{{.*}}_Cmacro_Py_None, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cmacro_Py_True, ptr @main._cgo_{{.*}}_Cmacro_Py_True, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_fputs, ptr @main._cgo_{{.*}}_Cfunc_fputs, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cmacro_stdout, ptr @main._cgo_{{.*}}_Cmacro_stdout, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_test_stdout, ptr @main._cgo_{{.*}}_Cfunc_test_stdout, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgomacro.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call [0 x i8] @"{{.*}}/cl/_testgo/cgomacro._Cfunc_test_stdout"()
-// CHECK-NEXT:   %1 = call i32 @"{{.*}}/cl/_testgo/cgomacro.main$1"()
-// CHECK-NEXT:   %2 = call [0 x i8] @"{{.*}}/cl/_testgo/cgomacro._Cfunc_Py_Initialize"()
+// CHECK-NEXT:   %0 = call [0 x i8] @main._Cfunc_test_stdout()
+// CHECK-NEXT:   %1 = call i32 @"main.main$1"()
+// CHECK-NEXT:   %2 = call [0 x i8] @main._Cfunc_Py_Initialize()
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()
 // CHECK-NEXT:   %4 = alloca i8, i64 {{.*}}, align 1
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
@@ -130,7 +130,7 @@ import (
 // CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 2
 // CHECK-NEXT:   store ptr %3, ptr %8, align 8
 // CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 3
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgomacro.main", %_llgo_2), ptr %9, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_2), ptr %9, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %5)
 // CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 1
 // CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 3
@@ -145,9 +145,9 @@ import (
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgomacro.main", %_llgo_3), ptr %11, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_3), ptr %11, align 8
 // CHECK-NEXT:   %16 = load i64, ptr %10, align 8
-// CHECK-NEXT:   %17 = call [0 x i8] @"{{.*}}/cl/_testgo/cgomacro._Cfunc_Py_Finalize"()
+// CHECK-NEXT:   %17 = call [0 x i8] @main._Cfunc_Py_Finalize()
 // CHECK-NEXT:   %18 = load %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, align 8
 // CHECK-NEXT:   %19 = extractvalue %"{{.*}}/runtime/internal/runtime.Defer" %18, 2
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %19)
@@ -159,17 +159,17 @@ import (
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %21 = call i32 @"{{.*}}/cl/_testgo/cgomacro.main$2"()
-// CHECK-NEXT:   %22 = call i32 @"{{.*}}/cl/_testgo/cgomacro.main$3"()
-// CHECK-NEXT:   %23 = call i32 @"{{.*}}/cl/_testgo/cgomacro.main$4"()
-// CHECK-NEXT:   %24 = call i32 @"{{.*}}/cl/_testgo/cgomacro.main$5"()
-// CHECK-NEXT:   %25 = call i32 @"{{.*}}/cl/_testgo/cgomacro.main$6"()
-// CHECK-NEXT:   %26 = call i32 @"{{.*}}/cl/_testgo/cgomacro.main$7"()
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgomacro.main", %_llgo_6), ptr %12, align 8
+// CHECK-NEXT:   %21 = call i32 @"main.main$2"()
+// CHECK-NEXT:   %22 = call i32 @"main.main$3"()
+// CHECK-NEXT:   %23 = call i32 @"main.main$4"()
+// CHECK-NEXT:   %24 = call i32 @"main.main$5"()
+// CHECK-NEXT:   %25 = call i32 @"main.main$6"()
+// CHECK-NEXT:   %26 = call i32 @"main.main$7"()
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_6), ptr %12, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgomacro.main", %_llgo_3), ptr %12, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_3), ptr %12, align 8
 // CHECK-NEXT:   %27 = load ptr, ptr %11, align 8
 // CHECK-NEXT:   indirectbr ptr %27, [label %_llgo_3, label %_llgo_2]
 // CHECK-EMPTY:
@@ -189,64 +189,64 @@ func main() {
 	C.fputs((*C.char)(unsafe.Pointer(c.Str("\n"))), C.stdout)
 }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro.main$1"(){{.*}} {
+// CHECK-LABEL: define i32 @"main.main$1"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_stdout"()
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = call i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_fputs"(ptr @0, ptr %0)
+// CHECK-NEXT:   %0 = call ptr @main._Cmacro_stdout()
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %2 = call i32 @main._Cfunc_fputs(ptr @0, ptr %0)
 // CHECK-NEXT:   ret i32 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro.main$2"(){{.*}} {
+// CHECK-LABEL: define i32 @"main.main$2"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_Py_True"()
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_stdout"()
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__object", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   %4 = call i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_PyObject_Print"(ptr %0, ptr %1, i32 0)
+// CHECK-NEXT:   %0 = call ptr @main._Cmacro_Py_True()
+// CHECK-NEXT:   %1 = call ptr @main._Cmacro_stdout()
+// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__object", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %4 = call i32 @main._Cfunc_PyObject_Print(ptr %0, ptr %1, i32 0)
 // CHECK-NEXT:   ret i32 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro.main$3"(){{.*}} {
+// CHECK-LABEL: define i32 @"main.main$3"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_stdout"()
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = call i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_fputs"(ptr @{{.*}}, ptr %0)
+// CHECK-NEXT:   %0 = call ptr @main._Cmacro_stdout()
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %2 = call i32 @main._Cfunc_fputs(ptr @{{.*}}, ptr %0)
 // CHECK-NEXT:   ret i32 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro.main$4"(){{.*}} {
+// CHECK-LABEL: define i32 @"main.main$4"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_Py_False"()
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_stdout"()
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__object", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   %4 = call i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_PyObject_Print"(ptr %0, ptr %1, i32 0)
+// CHECK-NEXT:   %0 = call ptr @main._Cmacro_Py_False()
+// CHECK-NEXT:   %1 = call ptr @main._Cmacro_stdout()
+// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__object", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %4 = call i32 @main._Cfunc_PyObject_Print(ptr %0, ptr %1, i32 0)
 // CHECK-NEXT:   ret i32 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro.main$5"(){{.*}} {
+// CHECK-LABEL: define i32 @"main.main$5"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_stdout"()
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = call i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_fputs"(ptr @{{.*}}, ptr %0)
+// CHECK-NEXT:   %0 = call ptr @main._Cmacro_stdout()
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %2 = call i32 @main._Cfunc_fputs(ptr @{{.*}}, ptr %0)
 // CHECK-NEXT:   ret i32 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro.main$6"(){{.*}} {
+// CHECK-LABEL: define i32 @"main.main$6"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_Py_None"()
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_stdout"()
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__object", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   %4 = call i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_PyObject_Print"(ptr %0, ptr %1, i32 0)
+// CHECK-NEXT:   %0 = call ptr @main._Cmacro_Py_None()
+// CHECK-NEXT:   %1 = call ptr @main._Cmacro_stdout()
+// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__object", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %4 = call i32 @main._Cfunc_PyObject_Print(ptr %0, ptr %1, i32 0)
 // CHECK-NEXT:   ret i32 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgomacro.main$7"(){{.*}} {
+// CHECK-LABEL: define i32 @"main.main$7"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testgo/cgomacro._Cmacro_stdout"()
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/cgomacro._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = call i32 @"{{.*}}/cl/_testgo/cgomacro._Cfunc_fputs"(ptr @{{.*}}, ptr %0)
+// CHECK-NEXT:   %0 = call ptr @main._Cmacro_stdout()
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main._Ctype_struct__{{.*}}FILE", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %2 = call i32 @main._Cfunc_fputs(ptr @{{.*}}, ptr %0)
 // CHECK-NEXT:   ret i32 %2
 // CHECK-NEXT: }

--- a/cl/_testgo/cgopython/cgopython.go
+++ b/cl/_testgo/cgopython/cgopython.go
@@ -7,52 +7,52 @@ package main
 */
 import "C"
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/cgopython._Cfunc_PyRun_SimpleString"(ptr %0){{.*}} {
+// CHECK-LABEL: define i32 @main._Cfunc_PyRun_SimpleString(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testgo/cgopython._cgo_{{.*}}_Cfunc_PyRun_SimpleString", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_PyRun_SimpleString, align 8
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call i32 %3(ptr %0)
 // CHECK-NEXT:   ret i32 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/cgopython._Cfunc_Py_Finalize"(){{.*}} {
+// CHECK-LABEL: define [0 x i8] @main._Cfunc_Py_Finalize(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load ptr, ptr @"{{.*}}/cl/_testgo/cgopython._cgo_{{.*}}_Cfunc_Py_Finalize", align 8
+// CHECK-NEXT:   %0 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_Py_Finalize, align 8
 // CHECK-NEXT:   %1 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %2 = call [0 x i8] %1()
 // CHECK-NEXT:   ret [0 x i8] %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/cgopython._Cfunc_Py_Initialize"(){{.*}} {
+// CHECK-LABEL: define [0 x i8] @main._Cfunc_Py_Initialize(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load ptr, ptr @"{{.*}}/cl/_testgo/cgopython._cgo_{{.*}}_Cfunc_Py_Initialize", align 8
+// CHECK-NEXT:   %0 = load ptr, ptr @main._cgo_{{.*}}_Cfunc_Py_Initialize, align 8
 // CHECK-NEXT:   %1 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %2 = call [0 x i8] %1()
 // CHECK-NEXT:   ret [0 x i8] %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgopython.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/cgopython.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/cgopython.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @syscall.init()
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_PyRun_SimpleString, ptr @"{{.*}}/cl/_testgo/cgopython._cgo_{{.*}}_Cfunc_PyRun_SimpleString", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_Py_Finalize, ptr @"{{.*}}/cl/_testgo/cgopython._cgo_{{.*}}_Cfunc_Py_Finalize", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_Py_Initialize, ptr @"{{.*}}/cl/_testgo/cgopython._cgo_{{.*}}_Cfunc_Py_Initialize", align 8
-// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc__Cmalloc, ptr @"{{.*}}/cl/_testgo/cgopython._cgo_{{.*}}_Cfunc__Cmalloc", align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_PyRun_SimpleString, ptr @main._cgo_{{.*}}_Cfunc_PyRun_SimpleString, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_Py_Finalize, ptr @main._cgo_{{.*}}_Cfunc_Py_Finalize, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc_Py_Initialize, ptr @main._cgo_{{.*}}_Cfunc_Py_Initialize, align 8
+// CHECK-NEXT:   store ptr @_cgo_{{.*}}_Cfunc__Cmalloc, ptr @main._cgo_{{.*}}_Cfunc__Cmalloc, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cgopython.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call [0 x i8] @"{{.*}}/cl/_testgo/cgopython._Cfunc_Py_Initialize"()
+// CHECK-NEXT:   %0 = call [0 x i8] @main._Cfunc_Py_Initialize()
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()
 // CHECK-NEXT:   %2 = alloca i8, i64 {{.*}}, align 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
@@ -63,7 +63,7 @@ import "C"
 // CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %3, i32 0, i32 2
 // CHECK-NEXT:   store ptr %1, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %3, i32 0, i32 3
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgopython.main", %_llgo_2), ptr %7, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_2), ptr %7, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %3)
 // CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %3, i32 0, i32 1
 // CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %3, i32 0, i32 3
@@ -78,9 +78,9 @@ import "C"
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgopython.main", %_llgo_3), ptr %9, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_3), ptr %9, align 8
 // CHECK-NEXT:   %14 = load i64, ptr %8, align 8
-// CHECK-NEXT:   %15 = call [0 x i8] @"{{.*}}/cl/_testgo/cgopython._Cfunc_Py_Finalize"()
+// CHECK-NEXT:   %15 = call [0 x i8] @main._Cfunc_Py_Finalize()
 // CHECK-NEXT:   %16 = load %"{{.*}}/runtime/internal/runtime.Defer", ptr %3, align 8
 // CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.Defer" %16, 2
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %17)
@@ -93,12 +93,12 @@ import "C"
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.CString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 23 })
-// CHECK-NEXT:   %20 = call i32 @"{{.*}}/cl/_testgo/cgopython._Cfunc_PyRun_SimpleString"(ptr %19)
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgopython.main", %_llgo_6), ptr %10, align 8
+// CHECK-NEXT:   %20 = call i32 @main._Cfunc_PyRun_SimpleString(ptr %19)
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_6), ptr %10, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/cgopython.main", %_llgo_3), ptr %10, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_3), ptr %10, align 8
 // CHECK-NEXT:   %21 = load ptr, ptr %9, align 8
 // CHECK-NEXT:   indirectbr ptr %21, [label %_llgo_3, label %_llgo_2]
 // CHECK-EMPTY:

--- a/cl/_testgo/closure/in.go
+++ b/cl/_testgo/closure/in.go
@@ -3,18 +3,18 @@ package main
 
 type T func(n int)
 
-// CHECK-LABEL: define void @"{{.*}}closure.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 16)
 	// CHECK: store %"{{.*}}String" { ptr @0, i64 3 }, ptr %0, align 8
 	// CHECK: call ptr @"{{.*}}AllocU"(i64 8)
-	// CHECK: { ptr @"{{.*}}closure.main$2", ptr undef }
-	// CHECK: call void @"__llgo_stub.{{.*}}closure.main$1"(ptr null, i64 100)
+	// CHECK: { ptr @"main.main$2", ptr undef }
+	// CHECK: call void @"__llgo_stub.main.main$1"(ptr null, i64 100)
 	// CHECK: call void %7(ptr %6, i64 200)
 	// CHECK: ret void
 	var env string = "env"
 	var v1 T = func(i int) {
-		// CHECK-LABEL: define void @"{{.*}}closure.main$1"(i64 %0){{.*}} {
+		// CHECK-LABEL: define void @"main.main$1"(i64 %0){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @1, i64 4 })
 		// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 32)
@@ -24,7 +24,7 @@ func main() {
 		println("func", i)
 	}
 	var v2 T = func(i int) {
-		// CHECK-LABEL: define void @"{{.*}}closure.main$2"(ptr %0, i64 %1){{.*}} {
+		// CHECK-LABEL: define void @"main.main$2"(ptr %0, i64 %1){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
 		// CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0

--- a/cl/_testgo/closure2/in.go
+++ b/cl/_testgo/closure2/in.go
@@ -1,28 +1,28 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}closure2.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 8)
 	// CHECK: store i64 1, ptr %0, align 8
 	// CHECK: call ptr @"{{.*}}AllocU"(i64 8)
-	// CHECK: { ptr @"{{.*}}closure2.main$1", ptr undef }
+	// CHECK: { ptr @"main.main$1", ptr undef }
 	// CHECK: call { ptr, ptr } %5(ptr %4, i64 1)
 	// CHECK: call void %8(ptr %7, i64 2)
 	// CHECK: ret void
 	x := 1
 	f := func(i int) func(int) {
-		// CHECK-LABEL: define { ptr, ptr } @"{{.*}}closure2.main$1"(ptr %0, i64 %1){{.*}} {
+		// CHECK-LABEL: define { ptr, ptr } @"main.main$1"(ptr %0, i64 %1){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
 		// CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0
 		// CHECK-NEXT:   %4 = call ptr @"{{.*}}AllocU"(i64 8)
 		// CHECK-NEXT:   %5 = getelementptr inbounds { ptr }, ptr %4, i32 0, i32 0
 		// CHECK-NEXT:   store ptr %3, ptr %5, align 8
-		// CHECK-NEXT:   %6 = insertvalue { ptr, ptr } { ptr @"{{.*}}closure2.main$1$1", ptr undef }, ptr %4, 1
+		// CHECK-NEXT:   %6 = insertvalue { ptr, ptr } { ptr @"main.main$1$1", ptr undef }, ptr %4, 1
 		// CHECK-NEXT:   ret { ptr, ptr } %6
 		return func(i int) {
-			// CHECK-LABEL: define void @"{{.*}}closure2.main$1$1"(ptr %0, i64 %1){{.*}} {
+			// CHECK-LABEL: define void @"main.main$1$1"(ptr %0, i64 %1){{.*}} {
 			// CHECK-NEXT: _llgo_0:
 			// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
 			// CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0

--- a/cl/_testgo/closureall/in.go
+++ b/cl/_testgo/closureall/in.go
@@ -25,12 +25,12 @@ type S struct {
 	v int
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.S.Inc"(%"{{.*}}/cl/_testgo/closureall.S" %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.S.Inc(%main.S %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/closureall.S", align 8
+// CHECK-NEXT:   %2 = alloca %main.S, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/closureall.S" %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/closureall.S", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store %main.S %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load i64, ptr %3, align 8
 // CHECK-NEXT:   %5 = add i64 %4, %1
 // CHECK-NEXT:   ret i64 %5
@@ -40,9 +40,9 @@ func (s S) Inc(x int) int {
 	return s.v + x
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*S).Add"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/closureall.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.S, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
 // CHECK-NEXT:   %4 = add i64 %3, %1
 // CHECK-NEXT:   ret i64 %4
@@ -96,63 +96,63 @@ func makeWithFree(base int) Fn {
 	return func(x int) int { return x + base }
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Inc"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*S).Inc"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 3 })
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/closureall.S", ptr %0, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/closureall.S.Inc"(%"{{.*}}/cl/_testgo/closureall.S" %3, i64 %1)
+// CHECK-NEXT:   %3 = load %main.S, ptr %0, align 8
+// CHECK-NEXT:   %4 = call i64 @main.S.Inc(%main.S %3, i64 %1)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/closureall.callCallback"(ptr %0, i32 %1){{.*}} {
+// CHECK-LABEL: define i32 @main.callCallback(ptr %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = call i32 %0(i32 %1)
 // CHECK-NEXT:   ret i32 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.globalAdd"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.globalAdd(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/closureall.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/closureall.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/closureall.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/closureall.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeNoFree"()
-// CHECK-NEXT:   %1 = call %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeWithFree"(i64 3)
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/closureall.Fn" %0, 1
-// CHECK-NEXT:   %3 = extractvalue %"{{.*}}/cl/_testgo/closureall.Fn" %0, 0
+// CHECK-NEXT:   %0 = call %main.Fn @main.makeNoFree()
+// CHECK-NEXT:   %1 = call %main.Fn @main.makeWithFree(i64 3)
+// CHECK-NEXT:   %2 = extractvalue %main.Fn %0, 1
+// CHECK-NEXT:   %3 = extractvalue %main.Fn %0, 0
 // CHECK-NEXT:   %4 = call i64 %3(ptr %2, i64 1)
-// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/cl/_testgo/closureall.Fn" %1, 1
-// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/cl/_testgo/closureall.Fn" %1, 0
+// CHECK-NEXT:   %5 = extractvalue %main.Fn %1, 1
+// CHECK-NEXT:   %6 = extractvalue %main.Fn %1, 0
 // CHECK-NEXT:   %7 = call i64 %6(ptr %5, i64 2)
-// CHECK-NEXT:   %8 = call i64 @"{{.*}}/cl/_testgo/closureall.globalAdd"(i64 1, i64 2)
+// CHECK-NEXT:   %8 = call i64 @main.globalAdd(i64 1, i64 2)
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testgo/closureall.S", ptr %9, i32 0, i32 0
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.S, ptr %9, i32 0, i32 0
 // CHECK-NEXT:   store i64 5, ptr %10, align 8
 // CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %12 = getelementptr inbounds { ptr }, ptr %11, i32 0, i32 0
 // CHECK-NEXT:   store ptr %9, ptr %12, align 8
-// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/closureall.(*S).Add$bound", ptr undef }, ptr %11, 1
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } { ptr @"main.(*S).Add$bound", ptr undef }, ptr %11, 1
 // CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
 // CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
 // CHECK-NEXT:   %16 = call i64 %15(ptr %14, i64 7)
-// CHECK-NEXT:   %17 = call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add$thunk"(ptr %9, i64 8)
-// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", ptr @"*_llgo_{{.*}}/cl/_testgo/closureall.S")
+// CHECK-NEXT:   %17 = call i64 @"main.(*S).Add$thunk"(ptr %9, i64 8)
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.S")
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %18, 0
 // CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %19, ptr %9, 1
 // CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %20)
@@ -163,13 +163,13 @@ func makeWithFree(base int) Fn {
 // CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   %24 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %23, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %20, ptr %24, align 8
-// CHECK-NEXT:   %25 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/closureall.interface{Add(int) int}.Add$bound", ptr undef }, ptr %23, 1
+// CHECK-NEXT:   %25 = insertvalue { ptr, ptr } { ptr @"main.interface{Add(int) int}.Add$bound", ptr undef }, ptr %23, 1
 // CHECK-NEXT:   %26 = extractvalue { ptr, ptr } %25, 1
 // CHECK-NEXT:   %27 = extractvalue { ptr, ptr } %25, 0
 // CHECK-NEXT:   %28 = call i64 %27(ptr %26, i64 9)
 // CHECK-NEXT:   %29 = call double {{.*}}sqrt{{.*}}(double 4.000000e+00)
 // CHECK-NEXT:   %30 = call i32 @abs(i32 -3)
-// CHECK-NEXT:   %31 = call i32 @"{{.*}}/cl/_testgo/closureall.callCallback"(ptr @"{{.*}}/cl/_testgo/closureall.main$1", i32 7)
+// CHECK-NEXT:   %31 = call i32 @main.callCallback(ptr @"main.main$1", i32 7)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
@@ -177,38 +177,38 @@ func makeWithFree(base int) Fn {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/closureall.main$1"(i32 %0){{.*}} {
+// CHECK-LABEL: define i32 @"main.main$1"(i32 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = add i32 %0, 1
 // CHECK-NEXT:   ret i32 %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeNoFree"(){{.*}} {
+// CHECK-LABEL: define %main.Fn @main.makeNoFree(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/closureall.Fn" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/closureall.makeNoFree$1", ptr null }
+// CHECK-NEXT:   ret %main.Fn { ptr @"__llgo_stub.main.makeNoFree$1", ptr null }
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.makeNoFree$1"(i64 %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.makeNoFree$1"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = add i64 %0, 1
 // CHECK-NEXT:   ret i64 %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeWithFree"(i64 %0){{.*}} {
+// CHECK-LABEL: define %main.Fn @main.makeWithFree(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %3 = getelementptr inbounds { ptr }, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   store ptr %1, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/closureall.makeWithFree$1", ptr undef }, ptr %2, 1
-// CHECK-NEXT:   %5 = alloca %"{{.*}}/cl/_testgo/closureall.Fn", align 8
+// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"main.makeWithFree$1", ptr undef }, ptr %2, 1
+// CHECK-NEXT:   %5 = alloca %main.Fn, align 8
 // CHECK-NEXT:   store { ptr, ptr } %4, ptr %5, align 8
-// CHECK-NEXT:   %6 = load %"{{.*}}/cl/_testgo/closureall.Fn", ptr %5, align 8
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/closureall.Fn" %6
+// CHECK-NEXT:   %6 = load %main.Fn, ptr %5, align 8
+// CHECK-NEXT:   ret %main.Fn %6
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.makeWithFree$1"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.makeWithFree$1"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
 // CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0
@@ -217,17 +217,17 @@ func makeWithFree(base int) Fn {
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add$bound"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*S).Add$bound"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
 // CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %3, i64 %1)
+// CHECK-NEXT:   %4 = call i64 @"main.(*S).Add"(ptr %3, i64 %1)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add$thunk"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*S).Add$thunk"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %0, i64 %1)
+// CHECK-NEXT:   %2 = call i64 @"main.(*S).Add"(ptr %0, i64 %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
@@ -237,21 +237,21 @@ func makeWithFree(base int) Fn {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/closureall.S.Inc"(ptr %0, %"{{.*}}/cl/_testgo/closureall.S" %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.S.Inc(ptr %0, %main.S %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testgo/closureall.S.Inc"(%"{{.*}}/cl/_testgo/closureall.S" %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @main.S.Inc(%main.S %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*S).Add"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.(*S).Add"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/closureall.(*S).Inc"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*S).Inc"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Inc"(ptr %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.(*S).Inc"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
@@ -261,7 +261,7 @@ func makeWithFree(base int) Fn {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.interface{Add(int) int}.Add$bound"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.interface{Add(int) int}.Add$bound"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = load { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %0, align 8
 // CHECK-NEXT:   %3 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface" } %2, 0
@@ -277,8 +277,8 @@ func makeWithFree(base int) Fn {
 // CHECK-NEXT:   ret i64 %12
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/closureall.makeNoFree$1"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.makeNoFree$1"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/closureall.makeNoFree$1"(i64 %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.makeNoFree$1"(i64 %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }

--- a/cl/_testgo/constconv/in.go
+++ b/cl/_testgo/constconv/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}constconv.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	var i64 int64 = 1
 	var u64 uint64 = 1

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -32,11 +32,11 @@ func (c Cursor) Node() ast.Node {
 	return c.in.events[c.index].node
 }
 
-// CHECK-LABEL: define { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } @"{{.*}}/cl/_testgo/cursor.Cursor.FindNode"(%"{{.*}}/cl/_testgo/cursor.Cursor" %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { %main.Cursor, i1 } @main.Cursor.FindNode(%main.Cursor %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
+// CHECK-NEXT:   %2 = alloca %main.Cursor, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %0, ptr %2, align 8
+// CHECK-NEXT:   store %main.Cursor %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %1, ptr %3, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
@@ -44,7 +44,7 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   br i1 false, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %6 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %2, align 8
+// CHECK-NEXT:   %6 = load %main.Cursor, ptr %2, align 8
 // CHECK-NEXT:   %7 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %3, align 8
 // CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.iface", ptr %8, i64 0
@@ -52,7 +52,7 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   %10 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %8, 0
 // CHECK-NEXT:   %11 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %10, i64 1, 1
 // CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %11, i64 1, 2
-// CHECK-NEXT:   %13 = call %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" @"{{.*}}/cl/_testgo/cursor.Cursor.Preorder"(%"{{.*}}/cl/_testgo/cursor.Cursor" %6, %"{{.*}}/runtime/internal/runtime.Slice" %12)
+// CHECK-NEXT:   %13 = call %"iter.Seq[main.Cursor]" @main.Cursor.Preorder(%main.Cursor %6, %"{{.*}}/runtime/internal/runtime.Slice" %12)
 // CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 32)
 // CHECK-NEXT:   %16 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 0
@@ -63,9 +63,9 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   store ptr %4, ptr %18, align 8
 // CHECK-NEXT:   %19 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 3
 // CHECK-NEXT:   store ptr %5, ptr %19, align 8
-// CHECK-NEXT:   %20 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/cursor.Cursor.FindNode$1", ptr undef }, ptr %15, 1
-// CHECK-NEXT:   %21 = extractvalue %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" %13, 1
-// CHECK-NEXT:   %22 = extractvalue %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" %13, 0
+// CHECK-NEXT:   %20 = insertvalue { ptr, ptr } { ptr @"main.Cursor.FindNode$1", ptr undef }, ptr %15, 1
+// CHECK-NEXT:   %21 = extractvalue %"iter.Seq[main.Cursor]" %13, 1
+// CHECK-NEXT:   %22 = extractvalue %"iter.Seq[main.Cursor]" %13, 0
 // CHECK-NEXT:   call void %22(ptr %21, { ptr, ptr } %20)
 // CHECK-NEXT:   %23 = load i64, ptr %14, align 8
 // CHECK-NEXT:   %24 = icmp eq i64 %23, -1
@@ -79,25 +79,25 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %25, 0
 // CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %28, i64 1, 1
 // CHECK-NEXT:   %30 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %29, i64 1, 2
-// CHECK-NEXT:   %31 = call i64 @"{{.*}}/cl/_testgo/cursor.maskOf"(%"{{.*}}/runtime/internal/runtime.Slice" %30)
-// CHECK-NEXT:   %32 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %31 = call i64 @main.maskOf(%"{{.*}}/runtime/internal/runtime.Slice" %30)
+// CHECK-NEXT:   %32 = getelementptr inbounds %main.Cursor, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %33 = load ptr, ptr %32, align 8
-// CHECK-NEXT:   %34 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Inspector", ptr %33, i32 0, i32 0
+// CHECK-NEXT:   %34 = getelementptr inbounds %main.Inspector, ptr %33, i32 0, i32 0
 // CHECK-NEXT:   %35 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %34, align 8
-// CHECK-NEXT:   %36 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %2, align 8
-// CHECK-NEXT:   %37 = call { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %36)
+// CHECK-NEXT:   %36 = load %main.Cursor, ptr %2, align 8
+// CHECK-NEXT:   %37 = call { i32, i32 } @main.Cursor.indices(%main.Cursor %36)
 // CHECK-NEXT:   %38 = extractvalue { i32, i32 } %37, 0
 // CHECK-NEXT:   %39 = extractvalue { i32, i32 } %37, 1
 // CHECK-NEXT:   br label %_llgo_9
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_7, %_llgo_6
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" zeroinitializer, ptr %4, align 8
+// CHECK-NEXT:   store %main.Cursor zeroinitializer, ptr %4, align 8
 // CHECK-NEXT:   store i1 false, ptr %5, align 1
-// CHECK-NEXT:   %40 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %4, align 8
+// CHECK-NEXT:   %40 = load %main.Cursor, ptr %4, align 8
 // CHECK-NEXT:   %41 = load i1, ptr %5, align 1
-// CHECK-NEXT:   %42 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } undef, %"{{.*}}/cl/_testgo/cursor.Cursor" %40, 0
-// CHECK-NEXT:   %43 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %42, i1 %41, 1
-// CHECK-NEXT:   ret { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %43
+// CHECK-NEXT:   %42 = insertvalue { %main.Cursor, i1 } undef, %main.Cursor %40, 0
+// CHECK-NEXT:   %43 = insertvalue { %main.Cursor, i1 } %42, i1 %41, 1
+// CHECK-NEXT:   ret { %main.Cursor, i1 } %43
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
@@ -119,11 +119,11 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   br i1 %47, label %_llgo_8, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_7
-// CHECK-NEXT:   %48 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %4, align 8
+// CHECK-NEXT:   %48 = load %main.Cursor, ptr %4, align 8
 // CHECK-NEXT:   %49 = load i1, ptr %5, align 1
-// CHECK-NEXT:   %50 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } undef, %"{{.*}}/cl/_testgo/cursor.Cursor" %48, 0
-// CHECK-NEXT:   %51 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %50, i1 %49, 1
-// CHECK-NEXT:   ret { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %51
+// CHECK-NEXT:   %50 = insertvalue { %main.Cursor, i1 } undef, %main.Cursor %48, 0
+// CHECK-NEXT:   %51 = insertvalue { %main.Cursor, i1 } %50, i1 %49, 1
+// CHECK-NEXT:   ret { %main.Cursor, i1 } %51
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_13, %_llgo_2
 // CHECK-NEXT:   %52 = phi i32 [ %38, %_llgo_2 ], [ %75, %_llgo_13 ]
@@ -131,7 +131,7 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   br i1 %53, label %_llgo_10, label %_llgo_11
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_9
-// CHECK-NEXT:   %54 = alloca %"{{.*}}/cl/_testgo/cursor.event", align 8
+// CHECK-NEXT:   %54 = alloca %main.event, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %54, i8 0, i64 32, i1 false)
 // CHECK-NEXT:   %55 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 0
 // CHECK-NEXT:   %56 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 1
@@ -140,25 +140,25 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   %59 = icmp uge i64 %57, %56
 // CHECK-NEXT:   %60 = or i1 %59, %58
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %60, i64 %57, i1 true, i64 %56)
-// CHECK-NEXT:   %61 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %55, i64 %57
-// CHECK-NEXT:   %62 = load %"{{.*}}/cl/_testgo/cursor.event", ptr %61, align 8
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.event" %62, ptr %54, align 8
-// CHECK-NEXT:   %63 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %54, i32 0, i32 2
+// CHECK-NEXT:   %61 = getelementptr inbounds %main.event, ptr %55, i64 %57
+// CHECK-NEXT:   %62 = load %main.event, ptr %61, align 8
+// CHECK-NEXT:   store %main.event %62, ptr %54, align 8
+// CHECK-NEXT:   %63 = getelementptr inbounds %main.event, ptr %54, i32 0, i32 2
 // CHECK-NEXT:   %64 = load i32, ptr %63, align 4
 // CHECK-NEXT:   %65 = icmp sgt i32 %64, %52
 // CHECK-NEXT:   br i1 %65, label %_llgo_12, label %_llgo_13
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_9
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" zeroinitializer, ptr %4, align 8
+// CHECK-NEXT:   store %main.Cursor zeroinitializer, ptr %4, align 8
 // CHECK-NEXT:   store i1 false, ptr %5, align 1
-// CHECK-NEXT:   %66 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %4, align 8
+// CHECK-NEXT:   %66 = load %main.Cursor, ptr %4, align 8
 // CHECK-NEXT:   %67 = load i1, ptr %5, align 1
-// CHECK-NEXT:   %68 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } undef, %"{{.*}}/cl/_testgo/cursor.Cursor" %66, 0
-// CHECK-NEXT:   %69 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %68, i1 %67, 1
-// CHECK-NEXT:   ret { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %69
+// CHECK-NEXT:   %68 = insertvalue { %main.Cursor, i1 } undef, %main.Cursor %66, 0
+// CHECK-NEXT:   %69 = insertvalue { %main.Cursor, i1 } %68, i1 %67, 1
+// CHECK-NEXT:   ret { %main.Cursor, i1 } %69
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_10
-// CHECK-NEXT:   %70 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %54, i32 0, i32 1
+// CHECK-NEXT:   %70 = getelementptr inbounds %main.event, ptr %54, i32 0, i32 1
 // CHECK-NEXT:   %71 = load i64, ptr %70, align 8
 // CHECK-NEXT:   %72 = and i64 %71, %31
 // CHECK-NEXT:   %73 = icmp ne i64 %72, 0
@@ -170,25 +170,25 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   br label %_llgo_9
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_16
-// CHECK-NEXT:   %76 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
+// CHECK-NEXT:   %76 = alloca %main.Cursor, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %76, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %77 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %76, i32 0, i32 0
-// CHECK-NEXT:   %78 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %77 = getelementptr inbounds %main.Cursor, ptr %76, i32 0, i32 0
+// CHECK-NEXT:   %78 = getelementptr inbounds %main.Cursor, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %79 = load ptr, ptr %78, align 8
-// CHECK-NEXT:   %80 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %76, i32 0, i32 1
+// CHECK-NEXT:   %80 = getelementptr inbounds %main.Cursor, ptr %76, i32 0, i32 1
 // CHECK-NEXT:   store ptr %79, ptr %77, align 8
 // CHECK-NEXT:   store i32 %52, ptr %80, align 4
-// CHECK-NEXT:   %81 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %76, align 8
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %81, ptr %4, align 8
+// CHECK-NEXT:   %81 = load %main.Cursor, ptr %76, align 8
+// CHECK-NEXT:   store %main.Cursor %81, ptr %4, align 8
 // CHECK-NEXT:   store i1 true, ptr %5, align 1
-// CHECK-NEXT:   %82 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %4, align 8
+// CHECK-NEXT:   %82 = load %main.Cursor, ptr %4, align 8
 // CHECK-NEXT:   %83 = load i1, ptr %5, align 1
-// CHECK-NEXT:   %84 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } undef, %"{{.*}}/cl/_testgo/cursor.Cursor" %82, 0
-// CHECK-NEXT:   %85 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %84, i1 %83, 1
-// CHECK-NEXT:   ret { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %85
+// CHECK-NEXT:   %84 = insertvalue { %main.Cursor, i1 } undef, %main.Cursor %82, 0
+// CHECK-NEXT:   %85 = insertvalue { %main.Cursor, i1 } %84, i1 %83, 1
+// CHECK-NEXT:   ret { %main.Cursor, i1 } %85
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_16, %_llgo_12
-// CHECK-NEXT:   %86 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %54, i32 0, i32 2
+// CHECK-NEXT:   %86 = getelementptr inbounds %main.event, ptr %54, i32 0, i32 2
 // CHECK-NEXT:   %87 = load i32, ptr %86, align 4
 // CHECK-NEXT:   %88 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 0
 // CHECK-NEXT:   %89 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 1
@@ -197,15 +197,15 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   %92 = icmp uge i64 %90, %89
 // CHECK-NEXT:   %93 = or i1 %92, %91
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %93, i64 %90, i1 true, i64 %89)
-// CHECK-NEXT:   %94 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %88, i64 %90
-// CHECK-NEXT:   %95 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %94, i32 0, i32 1
+// CHECK-NEXT:   %94 = getelementptr inbounds %main.event, ptr %88, i64 %90
+// CHECK-NEXT:   %95 = getelementptr inbounds %main.event, ptr %94, i32 0, i32 1
 // CHECK-NEXT:   %96 = load i64, ptr %95, align 8
 // CHECK-NEXT:   %97 = and i64 %96, %31
 // CHECK-NEXT:   %98 = icmp eq i64 %97, 0
 // CHECK-NEXT:   br i1 %98, label %_llgo_17, label %_llgo_13
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_12
-// CHECK-NEXT:   %99 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %54, i32 0, i32 0
+// CHECK-NEXT:   %99 = getelementptr inbounds %main.event, ptr %54, i32 0, i32 0
 // CHECK-NEXT:   %100 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %99, align 8
 // CHECK-NEXT:   %101 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %3, align 8
 // CHECK-NEXT:   %102 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %100)
@@ -497,7 +497,7 @@ const (
 	nValueSpec
 )
 
-// CHECK-LABEL: define i1 @"{{.*}}/cl/_testgo/cursor.Cursor.FindNode$1"(ptr %0, %"{{.*}}/cl/_testgo/cursor.Cursor" %1){{.*}} {
+// CHECK-LABEL: define i1 @"main.Cursor.FindNode$1"(ptr %0, %main.Cursor %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = load { ptr, ptr, ptr, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %3 = extractvalue { ptr, ptr, ptr, ptr } %2, 0
@@ -508,7 +508,7 @@ const (
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %6 = extractvalue { ptr, ptr, ptr, ptr } %2, 0
 // CHECK-NEXT:   store i64 -1, ptr %6, align 8
-// CHECK-NEXT:   %7 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/cursor.Cursor.Node"(%"{{.*}}/cl/_testgo/cursor.Cursor" %1)
+// CHECK-NEXT:   %7 = call %"{{.*}}/runtime/internal/runtime.iface" @main.Cursor.Node(%main.Cursor %1)
 // CHECK-NEXT:   %8 = extractvalue { ptr, ptr, ptr, ptr } %2, 1
 // CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %8, align 8
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %7)
@@ -531,7 +531,7 @@ const (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %21 = extractvalue { ptr, ptr, ptr, ptr } %2, 2
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %1, ptr %21, align 8
+// CHECK-NEXT:   store %main.Cursor %1, ptr %21, align 8
 // CHECK-NEXT:   %22 = extractvalue { ptr, ptr, ptr, ptr } %2, 3
 // CHECK-NEXT:   store i1 true, ptr %22, align 1
 // CHECK-NEXT:   %23 = extractvalue { ptr, ptr, ptr, ptr } %2, 0
@@ -544,12 +544,12 @@ const (
 // CHECK-NEXT:   ret i1 true
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/cursor.Cursor.Node"(%"{{.*}}/cl/_testgo/cursor.Cursor" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @main.Cursor.Node(%main.Cursor %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
+// CHECK-NEXT:   %1 = alloca %main.Cursor, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   store %main.Cursor %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Cursor, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load i32, ptr %2, align 4
 // CHECK-NEXT:   %4 = icmp slt i32 %3, 0
 // CHECK-NEXT:   br i1 %4, label %_llgo_1, label %_llgo_2
@@ -558,11 +558,11 @@ const (
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.Cursor, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %6 = load ptr, ptr %5, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Inspector", ptr %6, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.Inspector, ptr %6, i32 0, i32 0
 // CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %7, align 8
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.Cursor, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %10 = load i32, ptr %9, align 4
 // CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %8, 0
 // CHECK-NEXT:   %12 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %8, 1
@@ -571,43 +571,43 @@ const (
 // CHECK-NEXT:   %15 = icmp uge i64 %13, %12
 // CHECK-NEXT:   %16 = or i1 %15, %14
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %16, i64 %13, i1 true, i64 %12)
-// CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %11, i64 %13
-// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %17, i32 0, i32 0
+// CHECK-NEXT:   %17 = getelementptr inbounds %main.event, ptr %11, i64 %13
+// CHECK-NEXT:   %18 = getelementptr inbounds %main.event, ptr %17, i32 0, i32 0
 // CHECK-NEXT:   %19 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %18, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %19
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" @"{{.*}}/cl/_testgo/cursor.Cursor.Preorder"(%"{{.*}}/cl/_testgo/cursor.Cursor" %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define %"iter.Seq[main.Cursor]" @main.Cursor.Preorder(%main.Cursor %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %0, ptr %2, align 8
+// CHECK-NEXT:   store %main.Cursor %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/cursor.maskOf"(%"{{.*}}/runtime/internal/runtime.Slice" %1)
+// CHECK-NEXT:   %4 = call i64 @main.maskOf(%"{{.*}}/runtime/internal/runtime.Slice" %1)
 // CHECK-NEXT:   store i64 %4, ptr %3, align 8
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   %6 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 0
 // CHECK-NEXT:   store ptr %2, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 1
 // CHECK-NEXT:   store ptr %3, ptr %7, align 8
-// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/cursor.Cursor.Preorder$1", ptr undef }, ptr %5, 1
-// CHECK-NEXT:   %9 = alloca %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]", align 8
+// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } { ptr @"main.Cursor.Preorder$1", ptr undef }, ptr %5, 1
+// CHECK-NEXT:   %9 = alloca %"iter.Seq[main.Cursor]", align 8
 // CHECK-NEXT:   store { ptr, ptr } %8, ptr %9, align 8
-// CHECK-NEXT:   %10 = load %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]", ptr %9, align 8
-// CHECK-NEXT:   ret %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" %10
+// CHECK-NEXT:   %10 = load %"iter.Seq[main.Cursor]", ptr %9, align 8
+// CHECK-NEXT:   ret %"iter.Seq[main.Cursor]" %10
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cursor.Cursor.Preorder$1"(ptr %0, { ptr, ptr } %1){{.*}} {
+// CHECK-LABEL: define void @"main.Cursor.Preorder$1"(ptr %0, { ptr, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = load { ptr, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %3 = extractvalue { ptr, ptr } %2, 0
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.Cursor, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   %5 = load ptr, ptr %4, align 8
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Inspector", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.Inspector, ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %7 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %6, align 8
 // CHECK-NEXT:   %8 = extractvalue { ptr, ptr } %2, 0
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %8)
-// CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %9, align 8
-// CHECK-NEXT:   %11 = call { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %10)
+// CHECK-NEXT:   %10 = load %main.Cursor, ptr %9, align 8
+// CHECK-NEXT:   %11 = call { i32, i32 } @main.Cursor.indices(%main.Cursor %10)
 // CHECK-NEXT:   %12 = extractvalue { i32, i32 } %11, 0
 // CHECK-NEXT:   %13 = extractvalue { i32, i32 } %11, 1
 // CHECK-NEXT:   br label %_llgo_1
@@ -618,7 +618,7 @@ const (
 // CHECK-NEXT:   br i1 %15, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %16 = alloca %"{{.*}}/cl/_testgo/cursor.event", align 8
+// CHECK-NEXT:   %16 = alloca %main.event, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %16, i8 0, i64 32, i1 false)
 // CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
 // CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
@@ -627,10 +627,10 @@ const (
 // CHECK-NEXT:   %21 = icmp uge i64 %19, %18
 // CHECK-NEXT:   %22 = or i1 %21, %20
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %22, i64 %19, i1 true, i64 %18)
-// CHECK-NEXT:   %23 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %17, i64 %19
-// CHECK-NEXT:   %24 = load %"{{.*}}/cl/_testgo/cursor.event", ptr %23, align 8
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.event" %24, ptr %16, align 8
-// CHECK-NEXT:   %25 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %16, i32 0, i32 2
+// CHECK-NEXT:   %23 = getelementptr inbounds %main.event, ptr %17, i64 %19
+// CHECK-NEXT:   %24 = load %main.event, ptr %23, align 8
+// CHECK-NEXT:   store %main.event %24, ptr %16, align 8
+// CHECK-NEXT:   %25 = getelementptr inbounds %main.event, ptr %16, i32 0, i32 2
 // CHECK-NEXT:   %26 = load i32, ptr %25, align 4
 // CHECK-NEXT:   %27 = icmp sgt i32 %26, %14
 // CHECK-NEXT:   br i1 %27, label %_llgo_4, label %_llgo_5
@@ -639,7 +639,7 @@ const (
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %16, i32 0, i32 1
+// CHECK-NEXT:   %28 = getelementptr inbounds %main.event, ptr %16, i32 0, i32 1
 // CHECK-NEXT:   %29 = load i64, ptr %28, align 8
 // CHECK-NEXT:   %30 = extractvalue { ptr, ptr } %2, 1
 // CHECK-NEXT:   %31 = load i64, ptr %30, align 8
@@ -652,7 +652,7 @@ const (
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_7, %_llgo_4
-// CHECK-NEXT:   %35 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %16, i32 0, i32 2
+// CHECK-NEXT:   %35 = getelementptr inbounds %main.event, ptr %16, i32 0, i32 2
 // CHECK-NEXT:   %36 = load i32, ptr %35, align 4
 // CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
 // CHECK-NEXT:   %38 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
@@ -661,8 +661,8 @@ const (
 // CHECK-NEXT:   %41 = icmp uge i64 %39, %38
 // CHECK-NEXT:   %42 = or i1 %41, %40
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %42, i64 %39, i1 true, i64 %38)
-// CHECK-NEXT:   %43 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %37, i64 %39
-// CHECK-NEXT:   %44 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %43, i32 0, i32 1
+// CHECK-NEXT:   %43 = getelementptr inbounds %main.event, ptr %37, i64 %39
+// CHECK-NEXT:   %44 = getelementptr inbounds %main.event, ptr %43, i32 0, i32 1
 // CHECK-NEXT:   %45 = load i64, ptr %44, align 8
 // CHECK-NEXT:   %46 = extractvalue { ptr, ptr } %2, 1
 // CHECK-NEXT:   %47 = load i64, ptr %46, align 8
@@ -671,19 +671,19 @@ const (
 // CHECK-NEXT:   br i1 %49, label %_llgo_8, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %50 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
+// CHECK-NEXT:   %50 = alloca %main.Cursor, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %50, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %51 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %50, i32 0, i32 0
+// CHECK-NEXT:   %51 = getelementptr inbounds %main.Cursor, ptr %50, i32 0, i32 0
 // CHECK-NEXT:   %52 = extractvalue { ptr, ptr } %2, 0
-// CHECK-NEXT:   %53 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %52, i32 0, i32 0
+// CHECK-NEXT:   %53 = getelementptr inbounds %main.Cursor, ptr %52, i32 0, i32 0
 // CHECK-NEXT:   %54 = load ptr, ptr %53, align 8
-// CHECK-NEXT:   %55 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %50, i32 0, i32 1
+// CHECK-NEXT:   %55 = getelementptr inbounds %main.Cursor, ptr %50, i32 0, i32 1
 // CHECK-NEXT:   store ptr %54, ptr %51, align 8
 // CHECK-NEXT:   store i32 %14, ptr %55, align 4
-// CHECK-NEXT:   %56 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %50, align 8
+// CHECK-NEXT:   %56 = load %main.Cursor, ptr %50, align 8
 // CHECK-NEXT:   %57 = extractvalue { ptr, ptr } %1, 1
 // CHECK-NEXT:   %58 = extractvalue { ptr, ptr } %1, 0
-// CHECK-NEXT:   %59 = call i1 %58(ptr %57, %"{{.*}}/cl/_testgo/cursor.Cursor" %56)
+// CHECK-NEXT:   %59 = call i1 %58(ptr %57, %main.Cursor %56)
 // CHECK-NEXT:   br i1 %59, label %_llgo_6, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_6
@@ -691,20 +691,20 @@ const (
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %0){{.*}} {
+// CHECK-LABEL: define { i32, i32 } @main.Cursor.indices(%main.Cursor %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
+// CHECK-NEXT:   %1 = alloca %main.Cursor, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   store %main.Cursor %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Cursor, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load i32, ptr %2, align 4
 // CHECK-NEXT:   %4 = icmp slt i32 %3, 0
 // CHECK-NEXT:   br i1 %4, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.Cursor, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %6 = load ptr, ptr %5, align 8
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Inspector", ptr %6, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.Inspector, ptr %6, i32 0, i32 0
 // CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %7, align 8
 // CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %8, 1
 // CHECK-NEXT:   %10 = trunc i64 %9 to i32
@@ -712,13 +712,13 @@ const (
 // CHECK-NEXT:   ret { i32, i32 } %11
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.Cursor, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %13 = load i32, ptr %12, align 4
-// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %14 = getelementptr inbounds %main.Cursor, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %15 = load ptr, ptr %14, align 8
-// CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Inspector", ptr %15, i32 0, i32 0
+// CHECK-NEXT:   %16 = getelementptr inbounds %main.Inspector, ptr %15, i32 0, i32 0
 // CHECK-NEXT:   %17 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %16, align 8
-// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %18 = getelementptr inbounds %main.Cursor, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %19 = load i32, ptr %18, align 4
 // CHECK-NEXT:   %20 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %17, 0
 // CHECK-NEXT:   %21 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %17, 1
@@ -727,8 +727,8 @@ const (
 // CHECK-NEXT:   %24 = icmp uge i64 %22, %21
 // CHECK-NEXT:   %25 = or i1 %24, %23
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %25, i64 %22, i1 true, i64 %21)
-// CHECK-NEXT:   %26 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %20, i64 %22
-// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %26, i32 0, i32 2
+// CHECK-NEXT:   %26 = getelementptr inbounds %main.event, ptr %20, i64 %22
+// CHECK-NEXT:   %27 = getelementptr inbounds %main.event, ptr %26, i32 0, i32 2
 // CHECK-NEXT:   %28 = load i32, ptr %27, align 4
 // CHECK-NEXT:   %29 = add i32 %28, 1
 // CHECK-NEXT:   %30 = insertvalue { i32, i32 } undef, i32 %13, 0
@@ -736,43 +736,43 @@ const (
 // CHECK-NEXT:   ret { i32, i32 } %31
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } @"{{.*}}/cl/_testgo/cursor.(*Cursor).FindNode"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { %main.Cursor, i1 } @"main.(*Cursor).FindNode"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 47 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 8 })
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
-// CHECK-NEXT:   %4 = call { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } @"{{.*}}/cl/_testgo/cursor.Cursor.FindNode"(%"{{.*}}/cl/_testgo/cursor.Cursor" %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
-// CHECK-NEXT:   %5 = extractvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %4, 0
-// CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %4, 1
-// CHECK-NEXT:   %7 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } undef, %"{{.*}}/cl/_testgo/cursor.Cursor" %5, 0
-// CHECK-NEXT:   %8 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %7, i1 %6, 1
-// CHECK-NEXT:   ret { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %8
+// CHECK-NEXT:   %3 = load %main.Cursor, ptr %0, align 8
+// CHECK-NEXT:   %4 = call { %main.Cursor, i1 } @main.Cursor.FindNode(%main.Cursor %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %5 = extractvalue { %main.Cursor, i1 } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { %main.Cursor, i1 } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { %main.Cursor, i1 } undef, %main.Cursor %5, 0
+// CHECK-NEXT:   %8 = insertvalue { %main.Cursor, i1 } %7, i1 %6, 1
+// CHECK-NEXT:   ret { %main.Cursor, i1 } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/cursor.(*Cursor).Node"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.(*Cursor).Node"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 47 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/cursor.Cursor.Node"(%"{{.*}}/cl/_testgo/cursor.Cursor" %2)
+// CHECK-NEXT:   %2 = load %main.Cursor, ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @main.Cursor.Node(%main.Cursor %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" @"{{.*}}/cl/_testgo/cursor.(*Cursor).Preorder"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define %"iter.Seq[main.Cursor]" @"main.(*Cursor).Preorder"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 47 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 8 })
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
-// CHECK-NEXT:   %4 = call %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" @"{{.*}}/cl/_testgo/cursor.Cursor.Preorder"(%"{{.*}}/cl/_testgo/cursor.Cursor" %3, %"{{.*}}/runtime/internal/runtime.Slice" %1)
-// CHECK-NEXT:   ret %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" %4
+// CHECK-NEXT:   %3 = load %main.Cursor, ptr %0, align 8
+// CHECK-NEXT:   %4 = call %"iter.Seq[main.Cursor]" @main.Cursor.Preorder(%main.Cursor %3, %"{{.*}}/runtime/internal/runtime.Slice" %1)
+// CHECK-NEXT:   ret %"iter.Seq[main.Cursor]" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i32, i32 } @"{{.*}}/cl/_testgo/cursor.(*Cursor).indices"(ptr %0){{.*}} {
+// CHECK-LABEL: define { i32, i32 } @"main.(*Cursor).indices"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 47 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 7 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
-// CHECK-NEXT:   %3 = call { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %2)
+// CHECK-NEXT:   %2 = load %main.Cursor, ptr %0, align 8
+// CHECK-NEXT:   %3 = call { i32, i32 } @main.Cursor.indices(%main.Cursor %2)
 // CHECK-NEXT:   %4 = extractvalue { i32, i32 } %3, 0
 // CHECK-NEXT:   %5 = extractvalue { i32, i32 } %3, 1
 // CHECK-NEXT:   %6 = insertvalue { i32, i32 } undef, i32 %4, 0
@@ -780,13 +780,13 @@ const (
 // CHECK-NEXT:   ret { i32, i32 } %7
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cursor.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/cursor.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/cursor.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @"go/ast.init"()
 // CHECK-NEXT:   call void @iter.init()
 // CHECK-NEXT:   call void @math.init()
@@ -796,16 +796,16 @@ const (
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cursor.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.Cursor, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK-NEXT:   store ptr %2, ptr %1, align 8
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/cursor.maskOf"(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.maskOf(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   %2 = icmp eq i64 %1, 0
@@ -834,7 +834,7 @@ const (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %12, i64 %6, i1 true, i64 %9)
 // CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.iface", ptr %8, i64 %6
 // CHECK-NEXT:   %14 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %13, align 8
-// CHECK-NEXT:   %15 = call i64 @"{{.*}}/cl/_testgo/cursor.typeOf"(%"{{.*}}/runtime/internal/runtime.iface" %14)
+// CHECK-NEXT:   %15 = call i64 @main.typeOf(%"{{.*}}/runtime/internal/runtime.iface" %14)
 // CHECK-NEXT:   %16 = or i64 %4, %15
 // CHECK-NEXT:   br label %_llgo_3
 // CHECK-EMPTY:
@@ -842,7 +842,7 @@ const (
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/cursor.typeOf"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.typeOf(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %0)
 // CHECK-NEXT:   %2 = icmp eq ptr %1, @"*_llgo_go/ast.Ident"

--- a/cl/_testgo/defer5/in.go
+++ b/cl/_testgo/defer5/in.go
@@ -1,13 +1,13 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: GetThreadDefer
-	// CHECK: blockaddress(@"{{.*}}.main", %_llgo_2)
-	// CHECK: blockaddress(@"{{.*}}.main", %_llgo_8)
-	// CHECK: call void @"{{.*}}.main$1"()
-	// CHECK: call void @"{{.*}}.main$2"()
+	// CHECK: blockaddress(@main.main, %_llgo_2)
+	// CHECK: blockaddress(@main.main, %_llgo_8)
+	// CHECK: call void @"main.main$1"()
+	// CHECK: call void @"main.main$2"()
 	// CHECK: FreeDeferNode
 	// CHECK: FreeDeferNode
 	defer println("A")
@@ -25,10 +25,10 @@ func main() {
 	panic("panic in main")
 }
 
-// CHECK-LABEL: define void @"{{.*}}.main$1"(){{.*}} {
+// CHECK-LABEL: define void @"main.main$1"(){{.*}} {
 // CHECK: Recover
 // CHECK: PrintString
 // CHECK: PrintByte
-// CHECK-LABEL: define void @"{{.*}}.main$2"(){{.*}} {
+// CHECK-LABEL: define void @"main.main$2"(){{.*}} {
 // CHECK: PrintString
 // CHECK: PrintByte

--- a/cl/_testgo/deferloop/in.go
+++ b/cl/_testgo/deferloop/in.go
@@ -1,11 +1,11 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: GetThreadDefer
 	for i := 0; i < 3; i++ {
-		// CHECK: blockaddress(@"{{.*}}.main", %_llgo_6)
+		// CHECK: blockaddress(@main.main, %_llgo_6)
 		defer println("loop", i)
 	}
 	// CHECK: PrintString

--- a/cl/_testgo/embedunexport-1598/in.go
+++ b/cl/_testgo/embedunexport-1598/in.go
@@ -8,45 +8,45 @@ type Wrapped struct {
 	*embedunexport.Base
 }
 
-// CHECK-LABEL: define %"{{.*}}String" @"{{.*}}embedunexport-1598.Wrapped.Name"(%"{{.*}}embedunexport-1598.Wrapped" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}String" @main.Wrapped.Name(%main.Wrapped %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}embedunexport-1598.Wrapped", align 8
+// CHECK-NEXT:   %1 = alloca %main.Wrapped, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"{{.*}}embedunexport-1598.Wrapped" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}embedunexport-1598.Wrapped", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.Wrapped %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Wrapped, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call %"{{.*}}String" @"{{.*}}embedunexport.(*Base).Name"(ptr %3)
 // CHECK-NEXT:   ret %"{{.*}}String" %4
 
-// CHECK-LABEL: define void @"{{.*}}embedunexport-1598.Wrapped.setName"(%"{{.*}}embedunexport-1598.Wrapped" %0, %"{{.*}}String" %1){{.*}} {
+// CHECK-LABEL: define void @main.Wrapped.setName(%main.Wrapped %0, %"{{.*}}String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = alloca %"{{.*}}embedunexport-1598.Wrapped", align 8
+// CHECK-NEXT:   %2 = alloca %main.Wrapped, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"{{.*}}embedunexport-1598.Wrapped" %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}embedunexport-1598.Wrapped", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store %main.Wrapped %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.Wrapped, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
 // CHECK-NEXT:   call void @"{{.*}}embedunexport.(*Base).setName"(ptr %4, %"{{.*}}String" %1)
 // CHECK-NEXT:   ret void
 
-// CHECK-LABEL: define %"{{.*}}String" @"{{.*}}embedunexport-1598.(*Wrapped).Name"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}String" @"main.(*Wrapped).Name"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}embedunexport-1598.Wrapped", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.Wrapped, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
 // CHECK-NEXT:   %3 = call %"{{.*}}String" @"{{.*}}embedunexport.(*Base).Name"(ptr %2)
 // CHECK-NEXT:   ret %"{{.*}}String" %3
 
-// CHECK-LABEL: define void @"{{.*}}embedunexport-1598.(*Wrapped).setName"(ptr %0, %"{{.*}}String" %1){{.*}} {
+// CHECK-LABEL: define void @"main.(*Wrapped).setName"(ptr %0, %"{{.*}}String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}embedunexport-1598.Wrapped", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Wrapped, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   call void @"{{.*}}embedunexport.(*Base).setName"(ptr %3, %"{{.*}}String" %1)
 // CHECK-NEXT:   ret void
 
-// CHECK-LABEL: define void @"{{.*}}embedunexport-1598.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: call ptr @"{{.*}}embedunexport.NewBase"(%"{{.*}}String" { ptr @0, i64 4 })
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 8)
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}embedunexport.iface{{.*}}", ptr @"{{.*}}embedunexport-1598.Wrapped")
+	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}embedunexport.iface{{.*}}", ptr @"*_llgo_main.Wrapped")
 	// CHECK: call void @"{{.*}}embedunexport.Use"(%"{{.*}}iface" %5)
 	// CHECK: call ptr @"{{.*}}IfacePtrData"(%"{{.*}}iface" %5)
 	// CHECK: call %"{{.*}}String" %13(ptr %12)

--- a/cl/_testgo/equal/in.go
+++ b/cl/_testgo/equal/in.go
@@ -3,7 +3,7 @@ package main
 
 func test() {}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.assert"(i1 %0){{.*}} {
+// CHECK-LABEL: define void @main.assert(i1 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
@@ -23,61 +23,61 @@ func assert(cond bool) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/equal.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/equal.init$guard", align 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#1"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#2"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#3"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#4"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#5"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#6"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#7"()
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
+// CHECK-NEXT:   call void @"main.init#1"()
+// CHECK-NEXT:   call void @"main.init#2"()
+// CHECK-NEXT:   call void @"main.init#3"()
+// CHECK-NEXT:   call void @"main.init#4"()
+// CHECK-NEXT:   call void @"main.init#5"()
+// CHECK-NEXT:   call void @"main.init#6"()
+// CHECK-NEXT:   call void @"main.init#7"()
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#1"(){{.*}} {
+// CHECK-LABEL: define void @"main.init#1"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/equal.init#1$2", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.init#1$2", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   call void @main.assert(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 true)
 // CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %3, 0
 // CHECK-NEXT:   %5 = icmp ne ptr %4, null
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %5)
+// CHECK-NEXT:   call void @main.assert(i1 %5)
 // CHECK-NEXT:   %6 = extractvalue { ptr, ptr } %3, 0
 // CHECK-NEXT:   %7 = icmp ne ptr null, %6
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %7)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 %7)
+// CHECK-NEXT:   call void @main.assert(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 true)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 // func
 func init() {
 	fn1 := test
 	fn2 := func(i, j int) int { return i + j }
-	// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/equal.init#1$1"(i64 %0, i64 %1){{.*}} {
+	// CHECK-LABEL: define i64 @"main.init#1$1"(i64 %0, i64 %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = add i64 %0, %1
 	// CHECK-NEXT:   ret i64 %2
 	// CHECK-NEXT: }
 	var n int
 	fn3 := func() { println(n) }
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#1$2"(ptr %0){{.*}} {
+	// CHECK-LABEL: define void @"main.init#1$2"(ptr %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 	// CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
@@ -99,9 +99,9 @@ func init() {
 	assert(nil == fn4)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#2"(){{.*}} {
+// CHECK-LABEL: define void @"main.init#2"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 true)
 // CHECK-NEXT:   %0 = alloca [3 x i64], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 24, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -132,7 +132,7 @@ func init() {
 // CHECK-NEXT:   %19 = extractvalue [3 x i64] %9, 2
 // CHECK-NEXT:   %20 = icmp eq i64 %18, %19
 // CHECK-NEXT:   %21 = and i1 %17, %20
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %21)
+// CHECK-NEXT:   call void @main.assert(i1 %21)
 // CHECK-NEXT:   %22 = getelementptr inbounds i64, ptr %4, i64 1
 // CHECK-NEXT:   store i64 1, ptr %22, align 8
 // CHECK-NEXT:   %23 = load [3 x i64], ptr %0, align 8
@@ -150,7 +150,7 @@ func init() {
 // CHECK-NEXT:   %35 = icmp eq i64 %33, %34
 // CHECK-NEXT:   %36 = and i1 %32, %35
 // CHECK-NEXT:   %37 = xor i1 %36, true
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %37)
+// CHECK-NEXT:   call void @main.assert(i1 %37)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 // array
@@ -172,13 +172,13 @@ type T struct {
 
 type N struct{}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#3"(){{.*}} {
+// CHECK-LABEL: define void @"main.init#3"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr {{%[0-9]+}}, align 8
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }
 // CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
-// CHECK: call void @"{{.*}}/cl/_testgo/equal.assert"
+// CHECK: call void @main.assert
 // CHECK: ret void
 // CHECK-NEXT: }
 // struct
@@ -195,7 +195,7 @@ func init() {
 	assert(y != z)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#4"(){{.*}} {
+// CHECK-LABEL: define void @"main.init#4"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -211,17 +211,17 @@ func init() {
 // CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %10 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice{{.*}}"({{.*}})
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 true)
 // CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 0
 // CHECK-NEXT:   %12 = icmp ne ptr %11, null
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %12)
+// CHECK-NEXT:   call void @main.assert(i1 %12)
 // CHECK-NEXT:   %13 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %8, 0
 // CHECK-NEXT:   %14 = icmp ne ptr %13, null
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %14)
+// CHECK-NEXT:   call void @main.assert(i1 %14)
 // CHECK-NEXT:   %15 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %10, 0
 // CHECK-NEXT:   %16 = icmp ne ptr %15, null
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %16)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 %16)
+// CHECK-NEXT:   call void @main.assert(i1 true)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 // slice
@@ -238,7 +238,7 @@ func init() {
 	assert(b == nil)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#5"(){{.*}} {
+// CHECK-LABEL: define void @"main.init#5"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 100, ptr {{%[0-9]+}}, align 8
@@ -246,7 +246,7 @@ func init() {
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr {{%[0-9]+}}, align 8
 // CHECK: call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"
-// CHECK: call void @"{{.*}}/cl/_testgo/equal.assert"
+// CHECK: call void @main.assert
 // CHECK: ret void
 // CHECK-NEXT: }
 // iface
@@ -263,16 +263,16 @@ func init() {
 	assert(c != y)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#6"(){{.*}} {
+// CHECK-LABEL: define void @"main.init#6"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 0)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 0)
 // CHECK-NEXT:   %2 = icmp eq ptr %0, %0
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %2)
+// CHECK-NEXT:   call void @main.assert(i1 %2)
 // CHECK-NEXT:   %3 = icmp ne ptr %0, %1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %3)
+// CHECK-NEXT:   call void @main.assert(i1 %3)
 // CHECK-NEXT:   %4 = icmp ne ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %4)
+// CHECK-NEXT:   call void @main.assert(i1 %4)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 // chan
@@ -284,12 +284,12 @@ func init() {
 	assert(a != nil)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#7"(){{.*}} {
+// CHECK-LABEL: define void @"main.init#7"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
 // CHECK-NEXT:   %1 = icmp ne ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @main.assert(i1 %1)
+// CHECK-NEXT:   call void @main.assert(i1 true)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 // map
@@ -300,7 +300,7 @@ func init() {
 	assert(m2 == nil)
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/equal.main"{{.*}}
+// CHECK-LABEL: define {{.*}} @main.main{{.*}}
 // CHECK: ret void
 func main() {
 }

--- a/cl/_testgo/errors/in.go
+++ b/cl/_testgo/errors/in.go
@@ -3,12 +3,12 @@ package main
 
 // New returns an error that formats as the given text.
 // Each call to New returns a distinct error value even if the text is identical.
-// CHECK-LABEL: define %"{{.*}}iface" @"{{.*}}errors.New"(%"{{.*}}String" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}iface" @main.New(%"{{.*}}String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}AllocZ"(i64 16)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}errors.errorString", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.errorString, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}String" %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"{{.*}}errors.errorString")
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_main.errorString")
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}iface" undef, ptr %3, 0
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}iface" %4, ptr %1, 1
 // CHECK-NEXT:   ret %"{{.*}}iface" %5
@@ -21,18 +21,18 @@ type errorString struct {
 	s string
 }
 
-// CHECK-LABEL: define %"{{.*}}String" @"{{.*}}errors.(*errorString).Error"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}String" @"main.(*errorString).Error"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}errors.errorString", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.errorString, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}String", ptr %1, align 8
 // CHECK-NEXT:   ret %"{{.*}}String" %2
 func (e *errorString) Error() string {
 	return e.s
 }
 
-// CHECK-LABEL: define void @"{{.*}}errors.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
-	// CHECK: call %"{{.*}}iface" @"{{.*}}errors.New"(%"{{.*}}String" { ptr @7, i64 8 })
+	// CHECK: call %"{{.*}}iface" @main.New(%"{{.*}}String" { ptr @7, i64 8 })
 	// CHECK: call void @"{{.*}}PrintIface"(%"{{.*}}iface" %0)
 	// CHECK: call ptr @"{{.*}}IfacePtrData"(%"{{.*}}iface" %0)
 	// CHECK: call %"{{.*}}String" %8(ptr %7)

--- a/cl/_testgo/genericembediface/in.go
+++ b/cl/_testgo/genericembediface/in.go
@@ -19,21 +19,21 @@ type ReflectionServer interface {
 	ServerReflectionInfo(streamlib.BidiStreamingServer[Request, Response]) error
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.handler"(%"{{.*}}/runtime/internal/runtime.eface" %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @main.handler(%"{{.*}}/runtime/internal/runtime.eface" %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %0, 0
-// CHECK-NEXT:   %3 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/genericembediface.ReflectionServer", ptr %2)
+// CHECK-NEXT:   %3 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.ReflectionServer, ptr %2)
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %0, 1
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$ZzWqZgiYW4qfvEaEOnxMk0iM2CGUNdNCyXNPKgONU60", ptr %2)
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %2)
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %5, 0
 // CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %6, ptr %4, 1
 // CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]", ptr %8, i32 0, i32 0
+// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]", ptr %8, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %1, ptr %9, align 8
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$v_XV1q3uiNvAZy1sSF5r_9UE2XfxcttHV0UKe3XpAeo", ptr @"*_llgo_{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]")
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]")
 // CHECK-NEXT:   %11 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %10, 0
 // CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %11, ptr %8, 1
 // CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %7)
@@ -52,13 +52,13 @@ type ReflectionServer interface {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/genericembediface.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/genericembediface.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/genericembediface.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/genericembediface/streamlib.init"()
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
@@ -82,23 +82,23 @@ func (stream) Context() string {
 	return "Context"
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/genericembediface.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/genericembediface.server" zeroinitializer, ptr %0, align 1
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testgo/genericembediface.server", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   store %main.server zeroinitializer, ptr %0, align 1
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.server, ptr undef }, ptr %0, 1
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/genericembediface.stream" zeroinitializer, ptr %2, align 1
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$v_XV1q3uiNvAZy1sSF5r_9UE2XfxcttHV0UKe3XpAeo", ptr @"_llgo_{{.*}}/cl/_testgo/genericembediface.stream")
+// CHECK-NEXT:   store %main.stream zeroinitializer, ptr %2, align 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.stream)
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %3, 0
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %4, ptr %2, 1
-// CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.handler"(%"{{.*}}/runtime/internal/runtime.eface" %1, %"{{.*}}/runtime/internal/runtime.iface" %5)
+// CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.iface" @main.handler(%"{{.*}}/runtime/internal/runtime.eface" %1, %"{{.*}}/runtime/internal/runtime.iface" %5)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(%"{{.*}}/cl/_testgo/genericembediface.server" %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @main.server.ServerReflectionInfo(%main.server %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer
 // CHECK-NEXT: }
@@ -108,28 +108,28 @@ func main() {
 	println("pass")
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.(*server).ServerReflectionInfo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.(*server).ServerReflectionInfo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 20 })
 // CHECK-NEXT:   %3 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %3)
-// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(%"{{.*}}/cl/_testgo/genericembediface.server" zeroinitializer, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @main.server.ServerReflectionInfo(%main.server zeroinitializer, %"{{.*}}/runtime/internal/runtime.iface" %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.stream.Context(%main.stream %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 7 }
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.(*stream).Context"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.(*stream).Context"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 7 })
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" zeroinitializer)
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @main.stream.Context(%main.stream zeroinitializer)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 
@@ -139,9 +139,9 @@ func main() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.(*GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]).Context"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.(*GenericServerStream[main.Request,main.Response]).Context"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %1, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %2, 0
@@ -155,12 +155,12 @@ func main() {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %11
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response].Context"(%"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]" %0){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response].Context"(%"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]", align 8
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
@@ -174,15 +174,15 @@ func main() {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %12
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response].Context"(ptr %0, %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response].Context"(ptr %0, %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response].Context"(%"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]" %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response].Context"(%"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[main.Request,main.Response]" %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface/streamlib.(*GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]).Context"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface/streamlib.(*GenericServerStream[main.Request,main.Response]).Context"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.(*GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]).Context"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.(*GenericServerStream[main.Request,main.Response]).Context"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
 
@@ -192,26 +192,26 @@ func main() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface.(*server).ServerReflectionInfo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.(*server).ServerReflectionInfo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.(*server).ServerReflectionInfo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.(*server).ServerReflectionInfo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(ptr %0, %"{{.*}}/cl/_testgo/genericembediface.server" %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @__llgo_stub.main.server.ServerReflectionInfo(ptr %0, %main.server %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(%"{{.*}}/cl/_testgo/genericembediface.server" %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @main.server.ServerReflectionInfo(%main.server %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface.(*stream).Context"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.main.(*stream).Context"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.(*stream).Context"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"main.(*stream).Context"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface.stream.Context"(ptr %0, %"{{.*}}/cl/_testgo/genericembediface.stream" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @__llgo_stub.main.stream.Context(ptr %0, %main.stream %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @main.stream.Context(%main.stream %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }

--- a/cl/_testgo/genericiter/in.go
+++ b/cl/_testgo/genericiter/in.go
@@ -17,13 +17,13 @@ type Tree TreeG[int]
 
 type Iterator IteratorG[int]
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/genericiter.(*Tree).Ascend"(ptr %0, %"{{.*}}/cl/_testgo/genericiter.Iterator" %1){{.*}} {
+// CHECK-LABEL: define void @"main.(*Tree).Ascend"(ptr %0, %main.Iterator %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/genericiter.Iterator" %1, 0
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/cl/_testgo/genericiter.IteratorG[int]" undef, ptr %2, 0
-// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/cl/_testgo/genericiter.Iterator" %1, 1
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/cl/_testgo/genericiter.IteratorG[int]" %3, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/genericiter.(*TreeG[int]).Ascend"(ptr %0, %"{{.*}}/cl/_testgo/genericiter.IteratorG[int]" %5)
+// CHECK-NEXT:   %2 = extractvalue %main.Iterator %1, 0
+// CHECK-NEXT:   %3 = insertvalue %"main.IteratorG[int]" undef, ptr %2, 0
+// CHECK-NEXT:   %4 = extractvalue %main.Iterator %1, 1
+// CHECK-NEXT:   %5 = insertvalue %"main.IteratorG[int]" %3, ptr %4, 1
+// CHECK-NEXT:   call void @"main.(*TreeG[int]).Ascend"(ptr %0, %"main.IteratorG[int]" %5)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -31,17 +31,17 @@ func (t *Tree) Ascend(iterator Iterator) {
 	(*TreeG[int])(t).Ascend((IteratorG[int])(iterator))
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/genericiter.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/genericiter.main$1", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   %4 = alloca %"{{.*}}/cl/_testgo/genericiter.Iterator", align 8
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %4 = alloca %main.Iterator, align 8
 // CHECK-NEXT:   store { ptr, ptr } %3, ptr %4, align 8
-// CHECK-NEXT:   %5 = load %"{{.*}}/cl/_testgo/genericiter.Iterator", ptr %4, align 8
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/genericiter.(*Tree).Ascend"(ptr @"__llgo.moduleZeroSizedAlloc$", %"{{.*}}/cl/_testgo/genericiter.Iterator" %5)
+// CHECK-NEXT:   %5 = load %main.Iterator, ptr %4, align 8
+// CHECK-NEXT:   call void @"main.(*Tree).Ascend"(ptr @"__llgo.moduleZeroSizedAlloc$", %main.Iterator %5)
 // CHECK-NEXT:   %6 = load i64, ptr %0, align 8
 // CHECK-NEXT:   %7 = icmp ne i64 %6, 1
 // CHECK-NEXT:   br i1 %7, label %_llgo_1, label %_llgo_2
@@ -62,7 +62,7 @@ func (t *Tree) Ascend(iterator Iterator) {
 func main() {
 	var got int
 	tree := (*Tree)(new(TreeG[int]))
-	// CHECK-LABEL: define i1 @"{{.*}}/cl/_testgo/genericiter.main$1"(ptr %0, i64 %1){{.*}} {
+	// CHECK-LABEL: define i1 @"main.main$1"(ptr %0, i64 %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = add i64 %1, 1
 	// CHECK-NEXT:   %3 = load { ptr }, ptr %0, align 8
@@ -81,10 +81,10 @@ func main() {
 	println("ok")
 }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testgo/genericiter.(*TreeG[int]).Ascend"(ptr %0, %"{{.*}}/cl/_testgo/genericiter.IteratorG[int]" %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.(*TreeG[int]).Ascend"(ptr %0, %"main.IteratorG[int]" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/genericiter.IteratorG[int]" %1, 1
-// CHECK-NEXT:   %3 = extractvalue %"{{.*}}/cl/_testgo/genericiter.IteratorG[int]" %1, 0
+// CHECK-NEXT:   %2 = extractvalue %"main.IteratorG[int]" %1, 1
+// CHECK-NEXT:   %3 = extractvalue %"main.IteratorG[int]" %1, 0
 // CHECK-NEXT:   %4 = call i1 %3(ptr %2, i64 0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testgo/goroutine/in.go
+++ b/cl/_testgo/goroutine/in.go
@@ -1,22 +1,22 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}goroutine.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 1)
 	// CHECK: store i1 false, ptr %0, align 1
 	// CHECK: call ptr @"{{.*}}AllocRoot"(i64 16)
-	// CHECK: call void @"{{.*}}NewProc"(ptr @"{{.*}}goroutine._llgo_routine$1", ptr %1, i64 0)
+	// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$1", ptr %1, i64 0)
 	done := false
 	go println("hello")
 	go func(s string) {
 		// CHECK: call ptr @"{{.*}}AllocU"(i64 8)
-		// CHECK: { ptr @"{{.*}}goroutine.main$1", ptr undef }
+		// CHECK: { ptr @"main.main$1", ptr undef }
 		// CHECK: call ptr @"{{.*}}AllocRoot"(i64 32)
-		// CHECK: call void @"{{.*}}NewProc"(ptr @"{{.*}}goroutine._llgo_routine$2", ptr {{%[0-9]+}}, i64 0)
+		// CHECK: call void @"{{.*}}NewProc"(ptr @"main._llgo_routine$2", ptr {{%[0-9]+}}, i64 0)
 		// CHECK: call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @2, i64 1 })
 		// CHECK: ret void
-		// CHECK-LABEL: define void @"{{.*}}goroutine.main$1"(ptr %0, %"{{.*}}String" %1){{.*}} {
+		// CHECK-LABEL: define void @"main.main$1"(ptr %0, %"{{.*}}String" %1){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" %1)
 		// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
@@ -32,7 +32,7 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define ptr @"{{.*}}goroutine._llgo_routine$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define ptr @"main._llgo_routine$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { %"{{.*}}String" }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { %"{{.*}}String" } %1, 0
@@ -41,7 +41,7 @@ func main() {
 // CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
 // CHECK-NEXT:   ret ptr null
 
-// CHECK-LABEL: define ptr @"{{.*}}goroutine._llgo_routine$2"(ptr %0){{.*}} {
+// CHECK-LABEL: define ptr @"main._llgo_routine$2"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { { ptr, ptr }, %"{{.*}}String" }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { { ptr, ptr }, %"{{.*}}String" } %1, 0

--- a/cl/_testgo/ifaceconv/in.go
+++ b/cl/_testgo/ifaceconv/in.go
@@ -33,7 +33,7 @@ type I2 interface {
 type C0 struct{}
 type C1 struct{}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" %0){{.*}} {
+// CHECK-LABEL: define void @main.C1.f(%main.C1 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -107,60 +107,60 @@ func main() {
 	println("pass")
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C1).f"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*C1).f"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 1 })
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" zeroinitializer)
+// CHECK-NEXT:   call void @main.C1.f(%main.C1 zeroinitializer)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %0){{.*}} {
+// CHECK-LABEL: define void @main.C2.f(%main.C2 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %0){{.*}} {
+// CHECK-LABEL: define void @main.C2.g(%main.C2 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).f"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*C2).f"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 1 })
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" zeroinitializer)
+// CHECK-NEXT:   call void @main.C2.f(%main.C2 zeroinitializer)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).g"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*C2).g"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 1 })
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" zeroinitializer)
+// CHECK-NEXT:   call void @main.C2.g(%main.C2 zeroinitializer)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/ifaceconv.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/ifaceconv.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   br i1 false, label %_llgo_23, label %_llgo_24
 // CHECK-EMPTY:
@@ -203,16 +203,16 @@ func main() {
 // CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %13, 0
 // CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" %14, ptr null, 1
 // CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
-// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", ptr %16)
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface${{[-A-Za-z0-9_]+}}", ptr %16)
 // CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %17, 0
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %18, ptr null, 1
 // CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceconv.C1" zeroinitializer, ptr %20, align 1
-// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.C1")
+// CHECK-NEXT:   store %main.C1 zeroinitializer, ptr %20, align 1
+// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.C1)
 // CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %21, 0
 // CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %22, ptr %20, 1
 // CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %23)
-// CHECK-NEXT:   %25 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.I0", ptr %24)
+// CHECK-NEXT:   %25 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.I0, ptr %24)
 // CHECK-NEXT:   br i1 %25, label %_llgo_32, label %_llgo_33
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_34
@@ -236,7 +236,7 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_37
 // CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %23)
-// CHECK-NEXT:   %33 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.I2", ptr %32)
+// CHECK-NEXT:   %33 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.I2, ptr %32)
 // CHECK-NEXT:   br i1 %33, label %_llgo_38, label %_llgo_39
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_40
@@ -248,12 +248,12 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_40
 // CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceconv.C2" zeroinitializer, ptr %36, align 1
-// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.C2")
+// CHECK-NEXT:   store %main.C2 zeroinitializer, ptr %36, align 1
+// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.C2)
 // CHECK-NEXT:   %38 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %37, 0
 // CHECK-NEXT:   %39 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %38, ptr %36, 1
 // CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %39)
-// CHECK-NEXT:   %41 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.I0", ptr %40)
+// CHECK-NEXT:   %41 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.I0, ptr %40)
 // CHECK-NEXT:   br i1 %41, label %_llgo_41, label %_llgo_42
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_43
@@ -277,7 +277,7 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_46
 // CHECK-NEXT:   %48 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %39)
-// CHECK-NEXT:   %49 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.I2", ptr %48)
+// CHECK-NEXT:   %49 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.I2, ptr %48)
 // CHECK-NEXT:   br i1 %49, label %_llgo_47, label %_llgo_48
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_17:                                         ; preds = %_llgo_49
@@ -289,8 +289,8 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_18:                                         ; preds = %_llgo_49
 // CHECK-NEXT:   %52 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceconv.C1" zeroinitializer, ptr %52, align 1
-// CHECK-NEXT:   %53 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.C1")
+// CHECK-NEXT:   store %main.C1 zeroinitializer, ptr %52, align 1
+// CHECK-NEXT:   %53 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.C1)
 // CHECK-NEXT:   %54 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %53, 0
 // CHECK-NEXT:   %55 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %54, ptr %52, 1
 // CHECK-NEXT:   %56 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %55)
@@ -399,7 +399,7 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_38:                                         ; preds = %_llgo_10
 // CHECK-NEXT:   %95 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %23, 1
-// CHECK-NEXT:   %96 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", ptr %32)
+// CHECK-NEXT:   %96 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface${{[-A-Za-z0-9_]+}}", ptr %32)
 // CHECK-NEXT:   %97 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %96, 0
 // CHECK-NEXT:   %98 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %97, ptr %95, 1
 // CHECK-NEXT:   %99 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %98, 0
@@ -448,7 +448,7 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_47:                                         ; preds = %_llgo_16
 // CHECK-NEXT:   %117 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %39, 1
-// CHECK-NEXT:   %118 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", ptr %48)
+// CHECK-NEXT:   %118 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface${{[-A-Za-z0-9_]+}}", ptr %48)
 // CHECK-NEXT:   %119 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %118, 0
 // CHECK-NEXT:   %120 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %119, ptr %117, 1
 // CHECK-NEXT:   %121 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %120, 0
@@ -483,38 +483,38 @@ func main() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.(*C1).f"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.(*C1).f"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.(*C1).f"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.(*C1).f"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.C1.f"(ptr %0, %"{{.*}}/cl/_testgo/ifaceconv.C1" %1){{.*}} {
+// CHECK-LABEL: define linkonce void @__llgo_stub.main.C1.f(ptr %0, %main.C1 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" %1)
+// CHECK-NEXT:   tail call void @main.C1.f(%main.C1 %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.(*C2).f"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.(*C2).f"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).f"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.(*C2).f"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.(*C2).g"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.(*C2).g"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).g"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.(*C2).g"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.C2.f"(ptr %0, %"{{.*}}/cl/_testgo/ifaceconv.C2" %1){{.*}} {
+// CHECK-LABEL: define linkonce void @__llgo_stub.main.C2.f(ptr %0, %main.C2 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %1)
+// CHECK-NEXT:   tail call void @main.C2.f(%main.C2 %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.C2.g"(ptr %0, %"{{.*}}/cl/_testgo/ifaceconv.C2" %1){{.*}} {
+// CHECK-LABEL: define linkonce void @__llgo_stub.main.C2.g(ptr %0, %main.C2 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %1)
+// CHECK-NEXT:   tail call void @main.C2.g(%main.C2 %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testgo/ifaceprom/in.go
+++ b/cl/_testgo/ifaceprom/in.go
@@ -66,12 +66,12 @@ func main() {
 	println("pass")
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.S.one"(%"{{.*}}/cl/_testgo/ifaceprom.S" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.S.one(%main.S %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
+// CHECK-NEXT:   %1 = alloca %main.S, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.S" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.S %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.S, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
@@ -85,12 +85,12 @@ func main() {
 // CHECK-NEXT:   ret i64 %12
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.S.two"(%"{{.*}}/cl/_testgo/ifaceprom.S" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.S.two(%main.S %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
+// CHECK-NEXT:   %1 = alloca %main.S, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.S" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.S %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.S, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
@@ -104,9 +104,9 @@ func main() {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %12
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.(*S).one"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*S).one"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.S, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %1, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %2, 0
@@ -120,9 +120,9 @@ func main() {
 // CHECK-NEXT:   ret i64 %11
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.(*S).two"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.(*S).two"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.S, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %1, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %2, 0
@@ -136,61 +136,61 @@ func main() {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %11
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.impl.one"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.impl.one(%main.impl %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret i64 1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.impl.two"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.impl.two(%main.impl %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 }
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.(*impl).one"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*impl).one"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 48 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 3 })
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/ifaceprom.impl.one"(%"{{.*}}/cl/_testgo/ifaceprom.impl" zeroinitializer)
+// CHECK-NEXT:   %3 = call i64 @main.impl.one(%main.impl zeroinitializer)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.(*impl).two"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.(*impl).two"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 48 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 })
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.impl.two"(%"{{.*}}/cl/_testgo/ifaceprom.impl" zeroinitializer)
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @main.impl.two(%main.impl zeroinitializer)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceprom.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/ifaceprom.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/ifaceprom.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceprom.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
+// CHECK-NEXT:   %0 = alloca %main.S, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.S, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.impl" zeroinitializer, ptr %2, align 1
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceprom.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", ptr @"_llgo_{{.*}}/cl/_testgo/ifaceprom.impl")
+// CHECK-NEXT:   store %main.impl zeroinitializer, ptr %2, align 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceprom.iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.impl)
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %3, 0
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %4, ptr %2, 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %1, align 8
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.S, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %7 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %6, align 8
 // CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %7)
 // CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %7, 0
@@ -212,8 +212,8 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %20 = load %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, align 8
-// CHECK-NEXT:   %21 = extractvalue %"{{.*}}/cl/_testgo/ifaceprom.S" %20, 0
+// CHECK-NEXT:   %20 = load %main.S, ptr %0, align 8
+// CHECK-NEXT:   %21 = extractvalue %main.S %20, 0
 // CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %21)
 // CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %21, 0
 // CHECK-NEXT:   %24 = getelementptr ptr, ptr %23, i64 3
@@ -234,7 +234,7 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %34 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %34 = getelementptr inbounds %main.S, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %35 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %34, align 8
 // CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %35)
 // CHECK-NEXT:   %37 = icmp ne ptr %36, null
@@ -248,8 +248,8 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_17
-// CHECK-NEXT:   %40 = load %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, align 8
-// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/cl/_testgo/ifaceprom.S" %40, 0
+// CHECK-NEXT:   %40 = load %main.S, ptr %0, align 8
+// CHECK-NEXT:   %41 = extractvalue %main.S %40, 0
 // CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %41)
 // CHECK-NEXT:   %43 = icmp ne ptr %42, null
 // CHECK-NEXT:   br i1 %43, label %_llgo_19, label %_llgo_20
@@ -262,7 +262,7 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_19
-// CHECK-NEXT:   %46 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %46 = getelementptr inbounds %main.S, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %47 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %46, align 8
 // CHECK-NEXT:   %48 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %47)
 // CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %47, 0
@@ -285,8 +285,8 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_8
-// CHECK-NEXT:   %61 = load %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, align 8
-// CHECK-NEXT:   %62 = extractvalue %"{{.*}}/cl/_testgo/ifaceprom.S" %61, 0
+// CHECK-NEXT:   %61 = load %main.S, ptr %0, align 8
+// CHECK-NEXT:   %62 = extractvalue %main.S %61, 0
 // CHECK-NEXT:   %63 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %62)
 // CHECK-NEXT:   %64 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %62, 0
 // CHECK-NEXT:   %65 = getelementptr ptr, ptr %64, i64 4
@@ -308,7 +308,7 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_10
-// CHECK-NEXT:   %76 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %76 = getelementptr inbounds %main.S, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %77 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %76, align 8
 // CHECK-NEXT:   %78 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %77)
 // CHECK-NEXT:   %79 = icmp ne ptr %78, null
@@ -322,8 +322,8 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_21
-// CHECK-NEXT:   %82 = load %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, align 8
-// CHECK-NEXT:   %83 = extractvalue %"{{.*}}/cl/_testgo/ifaceprom.S" %82, 0
+// CHECK-NEXT:   %82 = load %main.S, ptr %0, align 8
+// CHECK-NEXT:   %83 = extractvalue %main.S %82, 0
 // CHECK-NEXT:   %84 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %83)
 // CHECK-NEXT:   %85 = icmp ne ptr %84, null
 // CHECK-NEXT:   br i1 %85, label %_llgo_23, label %_llgo_24
@@ -344,7 +344,7 @@ func main() {
 // CHECK-NEXT:   %88 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   %89 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %88, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %35, ptr %89, align 8
-// CHECK-NEXT:   %90 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/ifaceprom.I.one$bound", ptr undef }, ptr %88, 1
+// CHECK-NEXT:   %90 = insertvalue { ptr, ptr } { ptr @"main.I.one$bound", ptr undef }, ptr %88, 1
 // CHECK-NEXT:   %91 = extractvalue { ptr, ptr } %90, 1
 // CHECK-NEXT:   %92 = extractvalue { ptr, ptr } %90, 0
 // CHECK-NEXT:   %93 = call i64 %92(ptr %91)
@@ -359,7 +359,7 @@ func main() {
 // CHECK-NEXT:   %95 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   %96 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %95, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %41, ptr %96, align 8
-// CHECK-NEXT:   %97 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/ifaceprom.I.one$bound", ptr undef }, ptr %95, 1
+// CHECK-NEXT:   %97 = insertvalue { ptr, ptr } { ptr @"main.I.one$bound", ptr undef }, ptr %95, 1
 // CHECK-NEXT:   %98 = extractvalue { ptr, ptr } %97, 1
 // CHECK-NEXT:   %99 = extractvalue { ptr, ptr } %97, 0
 // CHECK-NEXT:   %100 = call i64 %99(ptr %98)
@@ -374,7 +374,7 @@ func main() {
 // CHECK-NEXT:   %102 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   %103 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %102, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %77, ptr %103, align 8
-// CHECK-NEXT:   %104 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/ifaceprom.I.two$bound", ptr undef }, ptr %102, 1
+// CHECK-NEXT:   %104 = insertvalue { ptr, ptr } { ptr @"main.I.two$bound", ptr undef }, ptr %102, 1
 // CHECK-NEXT:   %105 = extractvalue { ptr, ptr } %104, 1
 // CHECK-NEXT:   %106 = extractvalue { ptr, ptr } %104, 0
 // CHECK-NEXT:   %107 = call %"{{.*}}/runtime/internal/runtime.String" %106(ptr %105)
@@ -390,7 +390,7 @@ func main() {
 // CHECK-NEXT:   %110 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   %111 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %110, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %83, ptr %111, align 8
-// CHECK-NEXT:   %112 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/ifaceprom.I.two$bound", ptr undef }, ptr %110, 1
+// CHECK-NEXT:   %112 = insertvalue { ptr, ptr } { ptr @"main.I.two$bound", ptr undef }, ptr %110, 1
 // CHECK-NEXT:   %113 = extractvalue { ptr, ptr } %112, 1
 // CHECK-NEXT:   %114 = extractvalue { ptr, ptr } %112, 0
 // CHECK-NEXT:   %115 = call %"{{.*}}/runtime/internal/runtime.String" %114(ptr %113)
@@ -409,9 +409,9 @@ func main() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/ifaceprom.(*impl).one"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*impl).one"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/ifaceprom.(*impl).one"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*impl).one"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
@@ -421,21 +421,21 @@ func main() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/ifaceprom.(*impl).two"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.main.(*impl).two"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.(*impl).two"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"main.(*impl).two"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/ifaceprom.impl.one"(ptr %0, %"{{.*}}/cl/_testgo/ifaceprom.impl" %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.impl.one(ptr %0, %main.impl %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/ifaceprom.impl.one"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %1)
+// CHECK-NEXT:   %2 = tail call i64 @main.impl.one(%main.impl %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/ifaceprom.impl.two"(ptr %0, %"{{.*}}/cl/_testgo/ifaceprom.impl" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @__llgo_stub.main.impl.two(ptr %0, %main.impl %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.impl.two"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @main.impl.two(%main.impl %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
 
@@ -445,7 +445,7 @@ func main() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.I.one$bound"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.I.one$bound"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface" } %1, 0
@@ -461,7 +461,7 @@ func main() {
 // CHECK-NEXT:   ret i64 %11
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.I.two$bound"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.I.two$bound"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface" } %1, 0

--- a/cl/_testgo/interface/in.go
+++ b/cl/_testgo/interface/in.go
@@ -12,15 +12,15 @@ type Game1 struct {
 type Game2 struct {
 }
 
-// CHECK-LABEL: define void @"{{.*}}interface.(*Game2).initGame"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*Game2).initGame"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret void
 func (p *Game2) initGame() {
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/interface.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/interface.Game1"
+// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.Game1"
 // CHECK: call i1 @"{{.*}}/runtime/internal/runtime.Implements"
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.NewItab"
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintIface"

--- a/cl/_testgo/interface1370/in.go
+++ b/cl/_testgo/interface1370/in.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goplus/llgo/cl/_testdata/geometry1370"
 )
 
-// CHECK-LABEL: define void @"{{.*}}interface1370.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}geometry1370.NewRectangle"(double 5.000000e+00, double 3.000000e+00)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}NewItab"(ptr @"{{.*}}geometry1370.iface{{.*}}", ptr @"*_llgo_{{.*}}geometry1370.Rectangle")

--- a/cl/_testgo/invoke/in.go
+++ b/cl/_testgo/invoke/in.go
@@ -25,12 +25,12 @@ type T struct {
 	s string
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T.Invoke"(%"{{.*}}/cl/_testgo/invoke.T" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.T.Invoke(%main.T %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/invoke.T", align 8
+// CHECK-NEXT:   %1 = alloca %main.T, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.T %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.T, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.String", ptr %2, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 6 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -157,21 +157,21 @@ type M interface {
 	Method()
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T).Invoke"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T).Invoke"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 42 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/invoke.T", ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T.Invoke"(%"{{.*}}/cl/_testgo/invoke.T" %2)
+// CHECK-NEXT:   %2 = load %main.T, ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @main.T.Invoke(%main.T %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/invoke.(*T).Method"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*T).Method"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T1.Invoke"(i64 %0){{.*}} {
+// CHECK-LABEL: define i64 @main.T1.Invoke(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 7 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -180,16 +180,16 @@ type M interface {
 // CHECK-NEXT:   ret i64 1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T1).Invoke"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T1).Invoke"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
 // CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T1.Invoke"(i64 %2)
+// CHECK-NEXT:   %3 = call i64 @main.T1.Invoke(i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T2.Invoke"(double %0){{.*}} {
+// CHECK-LABEL: define i64 @main.T2.Invoke(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 7 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -198,16 +198,16 @@ type M interface {
 // CHECK-NEXT:   ret i64 2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T2).Invoke"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T2).Invoke"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
 // CHECK-NEXT:   %2 = load double, ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T2.Invoke"(double %2)
+// CHECK-NEXT:   %3 = call i64 @main.T2.Invoke(double %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T3).Invoke"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T3).Invoke"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
@@ -220,7 +220,7 @@ type M interface {
 // CHECK-NEXT:   ret i64 3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T4.Invoke"([1 x i64] %0){{.*}} {
+// CHECK-LABEL: define i64 @main.T4.Invoke([1 x i64] %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca [1 x i64], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
@@ -234,21 +234,21 @@ type M interface {
 // CHECK-NEXT:   ret i64 4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T4).Invoke"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T4).Invoke"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
 // CHECK-NEXT:   %2 = load [1 x i64], ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T4.Invoke"([1 x i64] %2)
+// CHECK-NEXT:   %3 = call i64 @main.T4.Invoke([1 x i64] %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T5.Invoke"(%"{{.*}}/cl/_testgo/invoke.T5" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.T5.Invoke(%main.T5 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/invoke.T5", align 8
+// CHECK-NEXT:   %1 = alloca %main.T5, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T5" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T5", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.T5 %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.T5, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @10, i64 7 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -257,19 +257,19 @@ type M interface {
 // CHECK-NEXT:   ret i64 5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T5).Invoke"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T5).Invoke"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/invoke.T5", ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T5.Invoke"(%"{{.*}}/cl/_testgo/invoke.T5" %2)
+// CHECK-NEXT:   %2 = load %main.T5, ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @main.T5.Invoke(%main.T5 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T6.Invoke"(%"{{.*}}/cl/_testgo/invoke.T6" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.T6.Invoke(%main.T6 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = extractvalue %"{{.*}}/cl/_testgo/invoke.T6" %0, 1
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/invoke.T6" %0, 0
+// CHECK-NEXT:   %1 = extractvalue %main.T6 %0, 1
+// CHECK-NEXT:   %2 = extractvalue %main.T6 %0, 0
 // CHECK-NEXT:   %3 = call i64 %2(ptr %1)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 7 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -278,29 +278,29 @@ type M interface {
 // CHECK-NEXT:   ret i64 6
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T6).Invoke"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T6).Invoke"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/invoke.T6", ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T6.Invoke"(%"{{.*}}/cl/_testgo/invoke.T6" %2)
+// CHECK-NEXT:   %2 = load %main.T6, ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @main.T6.Invoke(%main.T6 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/invoke.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/invoke.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/invoke.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
+// CHECK-LABEL: define void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %0)
 // CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %0, 0
@@ -316,10 +316,10 @@ type M interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/invoke.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 5 }, ptr %1, align 8
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 100, ptr %2, align 8
@@ -331,115 +331,115 @@ type M interface {
 // CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %5, i64 0
 // CHECK-NEXT:   store i64 200, ptr %6, align 8
 // CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T5", ptr %7, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %main.T5, ptr %7, i32 0, i32 0
 // CHECK-NEXT:   store i64 300, ptr %8, align 8
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T6" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/invoke.main$1", ptr null }, ptr %9, align 8
-// CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testgo/invoke.T", ptr %0, align 8
+// CHECK-NEXT:   store %main.T6 { ptr @"__llgo_stub.main.main$1", ptr null }, ptr %9, align 8
+// CHECK-NEXT:   %10 = load %main.T, ptr %0, align 8
 // CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T" %10, ptr %11, align 8
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T")
+// CHECK-NEXT:   store %main.T %10, ptr %11, align 8
+// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.T)
 // CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %12, 0
 // CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %13, ptr %11, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %14)
-// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T")
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %14)
+// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T")
 // CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %15, 0
 // CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %16, ptr %0, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %17)
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %17)
 // CHECK-NEXT:   %18 = load i64, ptr %2, align 8
 // CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 %18, ptr %19, align 8
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T1")
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.T1)
 // CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %20, 0
 // CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %21, ptr %19, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %22)
-// CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T1")
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %22)
+// CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T1")
 // CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %23, 0
 // CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %24, ptr %2, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %25)
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %25)
 // CHECK-NEXT:   %26 = load double, ptr %3, align 8
 // CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store double %26, ptr %27, align 8
-// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T2")
+// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.T2)
 // CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %28, 0
 // CHECK-NEXT:   %30 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %29, ptr %27, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %30)
-// CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T2")
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %30)
+// CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T2")
 // CHECK-NEXT:   %32 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %31, 0
 // CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %32, ptr %3, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %33)
-// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T3")
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %33)
+// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T3")
 // CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %34, 0
 // CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %35, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %36)
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %36)
 // CHECK-NEXT:   %37 = load [1 x i64], ptr %5, align 8
 // CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store [1 x i64] %37, ptr %38, align 8
-// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T4")
+// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.T4)
 // CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %39, 0
 // CHECK-NEXT:   %41 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %40, ptr %38, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %41)
-// CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T4")
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %41)
+// CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T4")
 // CHECK-NEXT:   %43 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %42, 0
 // CHECK-NEXT:   %44 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %43, ptr %5, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %44)
-// CHECK-NEXT:   %45 = load %"{{.*}}/cl/_testgo/invoke.T5", ptr %7, align 8
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %44)
+// CHECK-NEXT:   %45 = load %main.T5, ptr %7, align 8
 // CHECK-NEXT:   %46 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T5" %45, ptr %46, align 8
-// CHECK-NEXT:   %47 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T5")
+// CHECK-NEXT:   store %main.T5 %45, ptr %46, align 8
+// CHECK-NEXT:   %47 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.T5)
 // CHECK-NEXT:   %48 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %47, 0
 // CHECK-NEXT:   %49 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %48, ptr %46, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %49)
-// CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T5")
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %49)
+// CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T5")
 // CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %50, 0
 // CHECK-NEXT:   %52 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %51, ptr %7, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %52)
-// CHECK-NEXT:   %53 = load %"{{.*}}/cl/_testgo/invoke.T6", ptr %9, align 8
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %52)
+// CHECK-NEXT:   %53 = load %main.T6, ptr %9, align 8
 // CHECK-NEXT:   %54 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T6" %53, ptr %54, align 8
-// CHECK-NEXT:   %55 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T6")
+// CHECK-NEXT:   store %main.T6 %53, ptr %54, align 8
+// CHECK-NEXT:   %55 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.T6)
 // CHECK-NEXT:   %56 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %55, 0
 // CHECK-NEXT:   %57 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %56, ptr %54, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %57)
-// CHECK-NEXT:   %58 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T6")
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %57)
+// CHECK-NEXT:   %58 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T6")
 // CHECK-NEXT:   %59 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %58, 0
 // CHECK-NEXT:   %60 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %59, ptr %9, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %60)
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %60)
 // CHECK-NEXT:   %61 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
-// CHECK-NEXT:   %62 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %61)
+// CHECK-NEXT:   %62 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %61)
 // CHECK-NEXT:   %63 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %62, 0
 // CHECK-NEXT:   %64 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %63, ptr null, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintIface"(%"{{.*}}/runtime/internal/runtime.iface" %64)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintIface"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %65 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T")
+// CHECK-NEXT:   %65 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T")
 // CHECK-NEXT:   %66 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %65, 0
 // CHECK-NEXT:   %67 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %66, ptr %0, 1
 // CHECK-NEXT:   %68 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %67)
 // CHECK-NEXT:   %69 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %67, 1
-// CHECK-NEXT:   %70 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %68)
+// CHECK-NEXT:   %70 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %68)
 // CHECK-NEXT:   %71 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %70, 0
 // CHECK-NEXT:   %72 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %71, ptr %69, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %72)
-// CHECK-NEXT:   %73 = alloca %"{{.*}}/cl/_testgo/invoke.T", align 8
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %72)
+// CHECK-NEXT:   %73 = alloca %main.T, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %73, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %74 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T", ptr %73, i32 0, i32 0
+// CHECK-NEXT:   %74 = getelementptr inbounds %main.T, ptr %73, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @36, i64 5 }, ptr %74, align 8
-// CHECK-NEXT:   %75 = load %"{{.*}}/cl/_testgo/invoke.T", ptr %73, align 8
+// CHECK-NEXT:   %75 = load %main.T, ptr %73, align 8
 // CHECK-NEXT:   %76 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T" %75, ptr %76, align 8
-// CHECK-NEXT:   %77 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T", ptr undef }, ptr %76, 1
+// CHECK-NEXT:   store %main.T %75, ptr %76, align 8
+// CHECK-NEXT:   %77 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.T, ptr undef }, ptr %76, 1
 // CHECK-NEXT:   %78 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 0
-// CHECK-NEXT:   %79 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/invoke.I", ptr %78)
+// CHECK-NEXT:   %79 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.I, ptr %78)
 // CHECK-NEXT:   br i1 %79, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %80 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 1
-// CHECK-NEXT:   %81 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %78)
+// CHECK-NEXT:   %81 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %78)
 // CHECK-NEXT:   %82 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %81, 0
 // CHECK-NEXT:   %83 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %82, ptr %80, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %83)
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %83)
 // CHECK-NEXT:   %84 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 0
 // CHECK-NEXT:   %85 = icmp ne ptr %84, null
 // CHECK-NEXT:   br i1 %85, label %_llgo_3, label %_llgo_4
@@ -450,7 +450,7 @@ type M interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %86 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 0
-// CHECK-NEXT:   %87 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %86)
+// CHECK-NEXT:   %87 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %86)
 // CHECK-NEXT:   br i1 %87, label %_llgo_5, label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
@@ -459,10 +459,10 @@ type M interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
 // CHECK-NEXT:   %88 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 1
-// CHECK-NEXT:   %89 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %86)
+// CHECK-NEXT:   %89 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %86)
 // CHECK-NEXT:   %90 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %89, 0
 // CHECK-NEXT:   %91 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %90, ptr %88, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %91)
+// CHECK-NEXT:   call void @main.invoke(%"{{.*}}/runtime/internal/runtime.iface" %91)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_3
@@ -470,20 +470,20 @@ type M interface {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.main$1"(){{.*}} {
+// CHECK-LABEL: define i64 @"main.main$1"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret i64 400
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.main$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.main$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = tail call i64 @"{{.*}}/cl/_testgo/invoke.main$1"()
+// CHECK-NEXT:   %1 = tail call i64 @"main.main$1"()
 // CHECK-NEXT:   ret i64 %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.(*T).Invoke"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T).Invoke"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.(*T).Invoke"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T).Invoke"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
@@ -493,15 +493,15 @@ type M interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/invoke.(*T).Method"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.(*T).Method"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/invoke.(*T).Method"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.(*T).Method"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.T.Invoke"(ptr %0, %"{{.*}}/cl/_testgo/invoke.T" %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.T.Invoke(ptr %0, %main.T %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.T.Invoke"(%"{{.*}}/cl/_testgo/invoke.T" %1)
+// CHECK-NEXT:   %2 = tail call i64 @main.T.Invoke(%main.T %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
@@ -511,15 +511,15 @@ type M interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.(*T1).Invoke"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T1).Invoke"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.(*T1).Invoke"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T1).Invoke"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.T1.Invoke"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.T1.Invoke(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.T1.Invoke"(i64 %1)
+// CHECK-NEXT:   %2 = tail call i64 @main.T1.Invoke(i64 %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
@@ -529,15 +529,15 @@ type M interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.(*T2).Invoke"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T2).Invoke"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.(*T2).Invoke"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T2).Invoke"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.T2.Invoke"(ptr %0, double %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.T2.Invoke(ptr %0, double %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.T2.Invoke"(double %1)
+// CHECK-NEXT:   %2 = tail call i64 @main.T2.Invoke(double %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
@@ -547,45 +547,45 @@ type M interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.(*T3).Invoke"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T3).Invoke"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.(*T3).Invoke"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T3).Invoke"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.(*T4).Invoke"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T4).Invoke"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.(*T4).Invoke"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T4).Invoke"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.T4.Invoke"(ptr %0, [1 x i64] %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.T4.Invoke(ptr %0, [1 x i64] %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.T4.Invoke"([1 x i64] %1)
+// CHECK-NEXT:   %2 = tail call i64 @main.T4.Invoke([1 x i64] %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.(*T5).Invoke"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T5).Invoke"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.(*T5).Invoke"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T5).Invoke"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.T5.Invoke"(ptr %0, %"{{.*}}/cl/_testgo/invoke.T5" %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.T5.Invoke(ptr %0, %main.T5 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.T5.Invoke"(%"{{.*}}/cl/_testgo/invoke.T5" %1)
+// CHECK-NEXT:   %2 = tail call i64 @main.T5.Invoke(%main.T5 %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.(*T6).Invoke"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T6).Invoke"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.(*T6).Invoke"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*T6).Invoke"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.T6.Invoke"(ptr %0, %"{{.*}}/cl/_testgo/invoke.T6" %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.T6.Invoke(ptr %0, %main.T6 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/invoke.T6.Invoke"(%"{{.*}}/cl/_testgo/invoke.T6" %1)
+// CHECK-NEXT:   %2 = tail call i64 @main.T6.Invoke(%main.T6 %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 

--- a/cl/_testgo/localitycodegen/in.go
+++ b/cl/_testgo/localitycodegen/in.go
@@ -1,48 +1,48 @@
 // LITTEST
 package main
 
-// CHECK-DAG: @"{{.*}}localitycodegen.scalar" = thread_local global i64 0
-// CHECK-DAG: @"{{.*}}localitycodegen.__llgo_local_cache" = thread_local global i64 0
-// CHECK-DAG: @"{{.*}}localitycodegen.__llgo_tls_init$guard" = thread_local global i8 0
-// CHECK-DAG: @"{{.*}}localitycodegen.__llgo_tls_init$failure_cache" = thread_local global i64 0
+// CHECK-DAG: @main.scalar = thread_local global i64 0
+// CHECK-DAG: @main.__llgo_local_cache = thread_local global i64 0
+// CHECK-DAG: @"main.__llgo_tls_init$guard" = thread_local global i8 0
+// CHECK-DAG: @"main.__llgo_tls_init$failure_cache" = thread_local global i64 0
 // CHECK-NOT: RegisterLocalRoot
 // CHECK-NOT: localitycodegen.pointer" = thread_local
 // CHECK-NOT: localitycodegen.initialized" = thread_local
 
-// CHECK-LABEL: define ptr @"{{.*}}localitycodegen.__llgo_local_block"()
-// CHECK: load i64, ptr @"{{.*}}localitycodegen.__llgo_local_cache"
+// CHECK-LABEL: define ptr @main.__llgo_local_block()
+// CHECK: load i64, ptr @main.__llgo_local_cache
 // CHECK: icmp ne i64
 // CHECK: ret ptr
-// CHECK: call ptr @"{{.*}}runtime.LocalPackage"(ptr @"{{.*}}localitycodegen.__llgo_local_cache", i64 16, i64 8)
+// CHECK: call ptr @"{{.*}}runtime.LocalPackage"(ptr @main.__llgo_local_cache, i64 16, i64 8)
 // CHECK: ret ptr
 
-// CHECK-LABEL: define void @"{{.*}}localitycodegen.__llgo_tls_init"()
-// CHECK: call void @"{{.*}}localitycodegen.__llgo_local_init_0"()
+// CHECK-LABEL: define void @main.__llgo_tls_init()
+// CHECK: call void @main.__llgo_local_init_0()
 
-// CHECK-LABEL: define void @"{{.*}}localitycodegen.__llgo_tls_init$ensure"()
+// CHECK-LABEL: define void @"main.__llgo_tls_init$ensure"()
 // CHECK: load i8, ptr
-// CHECK: call void @"{{.*}}runtime.EnsureLocalInitializer"(ptr @"{{.*}}localitycodegen.__llgo_tls_init$guard", ptr @"{{.*}}localitycodegen.__llgo_tls_init$failure_cache"
+// CHECK: call void @"{{.*}}runtime.EnsureLocalInitializer"(ptr @"main.__llgo_tls_init$guard", ptr @"main.__llgo_tls_init$failure_cache"
 
 // CHECK-LABEL: define ptr @{{"?ExportedLocality"?}}()
 // CHECK: call i64 @"{{.*}}EnterLocalContext"
-// CHECK: call ptr @"{{.*}}localitycodegen.__llgo_local_block"()
+// CHECK: call ptr @main.__llgo_local_block()
 // CHECK: call void @"{{.*}}LeaveLocalContext"
 // CHECK: ret ptr
 
-// CHECK-LABEL: define void @"{{.*}}localitycodegen.init"()
+// CHECK-LABEL: define void @main.init()
 // CHECK: store i8 2, ptr
-// CHECK: call ptr @"{{.*}}localitycodegen.newPointer"()
-// CHECK: call void @"{{.*}}localitycodegen.__llgo_tls_init$ensure"()
-// CHECK: call ptr @"{{.*}}localitycodegen.__llgo_local_block"()
+// CHECK: call ptr @main.newPointer()
+// CHECK: call void @"main.__llgo_tls_init$ensure"()
+// CHECK: call ptr @main.__llgo_local_block()
 
-// CHECK-LABEL: define { i64, ptr, ptr } @"{{.*}}localitycodegen.values"()
-// CHECK: call void @"{{.*}}localitycodegen.__llgo_tls_init$ensure"()
-// CHECK: load i64, ptr @"{{.*}}localitycodegen.scalar"
-// CHECK: call ptr @"{{.*}}localitycodegen.__llgo_local_block"()
+// CHECK-LABEL: define { i64, ptr, ptr } @main.values()
+// CHECK: call void @"main.__llgo_tls_init$ensure"()
+// CHECK: load i64, ptr @main.scalar
+// CHECK: call ptr @main.__llgo_local_block()
 // CHECK: load ptr, ptr
 // CHECK: load ptr, ptr
 
-// CHECK-LABEL: define ptr @"{{.*}}localitycodegen._llgo_routine$1"(ptr %0)
+// CHECK-LABEL: define ptr @"main._llgo_routine$1"(ptr %0)
 // CHECK: alloca %"{{.*}}LocalContext", align 8
 // CHECK: call i64 @"{{.*}}EnterLocalContext"
 // CHECK: call void @"{{.*}}LeaveLocalContext"

--- a/cl/_testgo/makemaphint/in.go
+++ b/cl/_testgo/makemaphint/in.go
@@ -1,14 +1,14 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/makemaphint.fromInt32"(i32 %0){{.*}} {
+// CHECK-LABEL: define i64 @main.fromInt32(i32 %0){{.*}} {
 // CHECK: %1 = sext i32 %0 to i64
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_string]_llgo_int", i64 %1)
 func fromInt32(n int32) int {
 	return len(make(map[string]int, n))
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/makemaphint.fromUint32"(i32 %0){{.*}} {
+// CHECK-LABEL: define i64 @main.fromUint32(i32 %0){{.*}} {
 // CHECK: %1 = zext i32 %0 to i64
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_string]_llgo_int", i64 %1)
 func fromUint32(n uint32) int {

--- a/cl/_testgo/multiret/in.go
+++ b/cl/_testgo/multiret/in.go
@@ -3,9 +3,9 @@ package main
 
 var a int = 1
 
-// CHECK-LABEL: define { i64, double } @"{{.*}}multiret.foo"(double %0){{.*}} {
+// CHECK-LABEL: define { i64, double } @main.foo(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load i64, ptr @"{{.*}}multiret.a", align 8
+// CHECK-NEXT:   %1 = load i64, ptr @main.a, align 8
 // CHECK-NEXT:   %2 = insertvalue { i64, double } undef, i64 %1, 0
 // CHECK-NEXT:   %3 = insertvalue { i64, double } %2, double %0, 1
 // CHECK-NEXT:   ret { i64, double } %3
@@ -13,9 +13,9 @@ func foo(f float64) (int, float64) {
 	return a, f
 }
 
-// CHECK-LABEL: define void @"{{.*}}multiret.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
-	// CHECK: call { i64, double } @"{{.*}}multiret.foo"(double 2.000000e+00)
+	// CHECK: call { i64, double } @main.foo(double 2.000000e+00)
 	// CHECK-NEXT: %1 = extractvalue { i64, double } %0, 0
 	// CHECK-NEXT: %2 = extractvalue { i64, double } %0, 1
 	// CHECK-NEXT: call void @"{{.*}}PrintInt"(i64 %1)

--- a/cl/_testgo/print/in.go
+++ b/cl/_testgo/print/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}print.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: PrintInt"(i64 46)
 	// CHECK-NEXT: PrintByte"(i8 32)

--- a/cl/_testgo/reader/in.go
+++ b/cl/_testgo/reader/in.go
@@ -129,41 +129,41 @@ func WriteString(w Writer, s string) (n int, err error) {
 	return w.Write([]byte(s))
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.NopCloser"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @main.NopCloser(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %0)
-// CHECK-NEXT:   %2 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/reader.WriterTo", ptr %1)
+// CHECK-NEXT:   %2 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.WriterTo, ptr %1)
 // CHECK-NEXT:   br i1 %2, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %3 = alloca %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 8
+// CHECK-NEXT:   %3 = alloca %main.nopCloserWriterTo, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %3, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.nopCloserWriterTo, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %0, ptr %4, align 8
-// CHECK-NEXT:   %5 = load %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %3, align 8
+// CHECK-NEXT:   %5 = load %main.nopCloserWriterTo, ptr %3, align 8
 // CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84", ptr @"_llgo_{{.*}}/cl/_testgo/reader.nopCloserWriterTo")
+// CHECK-NEXT:   store %main.nopCloserWriterTo %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.nopCloserWriterTo)
 // CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %9
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %10 = alloca %"{{.*}}/cl/_testgo/reader.nopCloser", align 8
+// CHECK-NEXT:   %10 = alloca %main.nopCloser, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %10, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %10, i32 0, i32 0
+// CHECK-NEXT:   %11 = getelementptr inbounds %main.nopCloser, ptr %10, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %0, ptr %11, align 8
-// CHECK-NEXT:   %12 = load %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %10, align 8
+// CHECK-NEXT:   %12 = load %main.nopCloser, ptr %10, align 8
 // CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reader.nopCloser" %12, ptr %13, align 8
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84", ptr @"_llgo_{{.*}}/cl/_testgo/reader.nopCloser")
+// CHECK-NEXT:   store %main.nopCloser %12, ptr %13, align 8
+// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @_llgo_main.nopCloser)
 // CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %14, 0
 // CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %15, ptr %13, 1
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %16
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %0, 1
-// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs", ptr %1)
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %1)
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %18, 0
 // CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %19, ptr %17, 1
 // CHECK-NEXT:   %21 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %20, 0
@@ -203,7 +203,7 @@ func (c nopCloserWriterTo) WriteTo(w Writer) (n int64, err error) {
 	return c.Reader.(WriterTo).WriteTo(w)
 }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.ReadAll"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @main.ReadAll(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 512)
 // CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice2"(ptr %1, i64 1, i64 512, i64 0, i64 0, i1 true, i1 true, i1 true)
@@ -244,7 +244,7 @@ func (c nopCloserWriterTo) WriteTo(w Writer) (n int64, err error) {
 // CHECK-NEXT:   br i1 %33, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %34 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @"{{.*}}/cl/_testgo/reader.EOF", align 8
+// CHECK-NEXT:   %34 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @main.EOF, align 8
 // CHECK-NEXT:   %35 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %19)
 // CHECK-NEXT:   %36 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %19, 1
 // CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %35, 0
@@ -288,10 +288,10 @@ func (c nopCloserWriterTo) WriteTo(w Writer) (n int64, err error) {
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.WriteString"(%"{{.*}}/runtime/internal/runtime.iface" %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.WriteString(%"{{.*}}/runtime/internal/runtime.iface" %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %0)
-// CHECK-NEXT:   %3 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/reader.StringWriter", ptr %2)
+// CHECK-NEXT:   %3 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.StringWriter, ptr %2)
 // CHECK-NEXT:   br i1 %3, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
@@ -329,7 +329,7 @@ func (c nopCloserWriterTo) WriteTo(w Writer) (n int64, err error) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %31 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %0, 1
-// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", ptr %2)
+// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %2)
 // CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %32, 0
 // CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %33, ptr %31, 1
 // CHECK-NEXT:   %35 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %34, 0
@@ -502,25 +502,25 @@ type errorString struct {
 	s string
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reader.(*errorString).Error"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.(*errorString).Error"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.errorString", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.errorString, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.String", ptr %1, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reader.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/reader.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/reader.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @"unicode/utf8.init"()
-// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @28, i64 3 })
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %1, ptr @"{{.*}}/cl/_testgo/reader.EOF", align 8
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 11 })
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %2, ptr @"{{.*}}/cl/_testgo/reader.ErrShortWrite", align 8
+// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" { ptr @28, i64 3 })
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %1, ptr @main.EOF, align 8
+// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 11 })
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %2, ptr @main.ErrShortWrite, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -536,15 +536,15 @@ var (
 	ErrShortWrite = newError("short write")
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reader.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 11 }, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw", ptr @"*_llgo_{{.*}}/cl/_testgo/reader.stringReader")
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.stringReader")
 // CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
-// CHECK-NEXT:   %5 = call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.ReadAll"(%"{{.*}}/runtime/internal/runtime.iface" %4)
+// CHECK-NEXT:   %5 = call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @main.ReadAll(%"{{.*}}/runtime/internal/runtime.iface" %4)
 // CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
 // CHECK-NEXT:   %7 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
 // CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringFromBytes"(%"{{.*}}/runtime/internal/runtime.Slice" %6)
@@ -555,18 +555,18 @@ var (
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.errorString", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.errorString, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", ptr @"*_llgo_{{.*}}/cl/_testgo/reader.errorString")
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.errorString")
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %3, 0
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %4, ptr %1, 1
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloser.Close"(%"{{.*}}/cl/_testgo/reader.nopCloser" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @main.nopCloser.Close(%main.nopCloser %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer
 // CHECK-NEXT: }
@@ -577,12 +577,12 @@ func main() {
 	println(string(data), err)
 }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloser.Read"(%"{{.*}}/cl/_testgo/reader.nopCloser" %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.nopCloser.Read(%main.nopCloser %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/reader.nopCloser", align 8
+// CHECK-NEXT:   %2 = alloca %main.nopCloser, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reader.nopCloser" %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store %main.nopCloser %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.nopCloser, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %3, align 8
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
@@ -600,18 +600,18 @@ func main() {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %17
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*nopCloser).Close"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.(*nopCloser).Close"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @53, i64 50 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 5 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %0, align 8
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloser.Close"(%"{{.*}}/cl/_testgo/reader.nopCloser" %2)
+// CHECK-NEXT:   %2 = load %main.nopCloser, ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @main.nopCloser.Close(%main.nopCloser %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloser).Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*nopCloser).Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.nopCloser, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
@@ -629,17 +629,17 @@ func main() {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %16
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Close"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @main.nopCloserWriterTo.Close(%main.nopCloserWriterTo %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Read"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.nopCloserWriterTo.Read(%main.nopCloserWriterTo %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 8
+// CHECK-NEXT:   %2 = alloca %main.nopCloserWriterTo, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store %main.nopCloserWriterTo %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.nopCloserWriterTo, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %3, align 8
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
@@ -657,20 +657,20 @@ func main() {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %17
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.nopCloserWriterTo.WriteTo(%main.nopCloserWriterTo %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 8
+// CHECK-NEXT:   %2 = alloca %main.nopCloserWriterTo, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store %main.nopCloserWriterTo %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.nopCloserWriterTo, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %3, align 8
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %4)
-// CHECK-NEXT:   %6 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/reader.WriterTo", ptr %5)
+// CHECK-NEXT:   %6 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.WriterTo, ptr %5)
 // CHECK-NEXT:   br i1 %6, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %7 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 1
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs", ptr %5)
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr %5)
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %8, 0
 // CHECK-NEXT:   %10 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %9, ptr %7, 1
 // CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %10)
@@ -693,18 +693,18 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).Close"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.(*nopCloserWriterTo).Close"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 5 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Close"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %2)
+// CHECK-NEXT:   %2 = load %main.nopCloserWriterTo, ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @main.nopCloserWriterTo.Close(%main.nopCloserWriterTo %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*nopCloserWriterTo).Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.nopCloserWriterTo, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
@@ -722,12 +722,12 @@ func main() {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %16
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*nopCloserWriterTo).WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 7 })
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
-// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %3 = load %main.nopCloserWriterTo, ptr %0, align 8
+// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.nopCloserWriterTo.WriteTo(%main.nopCloserWriterTo %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
 // CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
 // CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
 // CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
@@ -735,11 +735,11 @@ func main() {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/reader.(*stringReader).Len"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*stringReader).Len"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %4 = load %"{{.*}}/runtime/internal/runtime.String", ptr %3, align 8
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %4, 1
 // CHECK-NEXT:   %6 = icmp sge i64 %2, %5
@@ -749,76 +749,76 @@ func main() {
 // CHECK-NEXT:   ret i64 0
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.String", ptr %7, align 8
 // CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %8, 1
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %11 = load i64, ptr %10, align 8
 // CHECK-NEXT:   %12 = sub i64 %9, %11
 // CHECK-NEXT:   ret i64 %12
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %5 = load %"{{.*}}/runtime/internal/runtime.String", ptr %4, align 8
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %5, 1
 // CHECK-NEXT:   %7 = icmp sge i64 %3, %6
 // CHECK-NEXT:   br i1 %7, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @"{{.*}}/cl/_testgo/reader.EOF", align 8
+// CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @main.EOF, align 8
 // CHECK-NEXT:   %9 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } { i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %8, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   store i64 -1, ptr %10, align 8
-// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %11 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %12 = load %"{{.*}}/runtime/internal/runtime.String", ptr %11, align 8
-// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %14 = load i64, ptr %13, align 8
 // CHECK-NEXT:   %15 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %12, 1
 // CHECK-NEXT:   %16 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringSlice2"(%"{{.*}}/runtime/internal/runtime.String" %12, i64 %14, i64 %15, i1 true, i1 true)
 // CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %16, 0
 // CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %16, 1
 // CHECK-NEXT:   %19 = call i64 @"{{.*}}/runtime/internal/runtime.SliceCopy"(%"{{.*}}/runtime/internal/runtime.Slice" %1, ptr %17, i64 %18, i64 1)
-// CHECK-NEXT:   %20 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %20 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %21 = load i64, ptr %20, align 8
 // CHECK-NEXT:   %22 = add i64 %21, %19
-// CHECK-NEXT:   %23 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %23 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %22, ptr %23, align 8
 // CHECK-NEXT:   %24 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %19, 0
 // CHECK-NEXT:   %25 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %24, %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %25
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).ReadAt"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1, i64 %2){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).ReadAt"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %3 = icmp slt i64 %2, 0
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 37 })
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 37 })
 // CHECK-NEXT:   %5 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } { i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %4, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %7 = load %"{{.*}}/runtime/internal/runtime.String", ptr %6, align 8
 // CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %7, 1
 // CHECK-NEXT:   %9 = icmp sge i64 %2, %8
 // CHECK-NEXT:   br i1 %9, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %10 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @"{{.*}}/cl/_testgo/reader.EOF", align 8
+// CHECK-NEXT:   %10 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @main.EOF, align 8
 // CHECK-NEXT:   %11 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } { i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %10, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %11
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %13 = load %"{{.*}}/runtime/internal/runtime.String", ptr %12, align 8
 // CHECK-NEXT:   %14 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %13, 1
 // CHECK-NEXT:   %15 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringSlice2"(%"{{.*}}/runtime/internal/runtime.String" %13, i64 %2, i64 %14, i1 true, i1 true)
@@ -830,7 +830,7 @@ func main() {
 // CHECK-NEXT:   br i1 %20, label %_llgo_5, label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %21 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @"{{.*}}/cl/_testgo/reader.EOF", align 8
+// CHECK-NEXT:   %21 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @main.EOF, align 8
 // CHECK-NEXT:   br label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
@@ -840,27 +840,27 @@ func main() {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %24
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).ReadByte"(ptr %0){{.*}} {
+// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).ReadByte"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   store i64 -1, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %5 = load %"{{.*}}/runtime/internal/runtime.String", ptr %4, align 8
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %5, 1
 // CHECK-NEXT:   %7 = icmp sge i64 %3, %6
 // CHECK-NEXT:   br i1 %7, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @"{{.*}}/cl/_testgo/reader.EOF", align 8
+// CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @main.EOF, align 8
 // CHECK-NEXT:   %9 = insertvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } { i8 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %8, 1
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %11 = load i64, ptr %10, align 8
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %13 = load %"{{.*}}/runtime/internal/runtime.String", ptr %12, align 8
 // CHECK-NEXT:   %14 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %13, 0
 // CHECK-NEXT:   %15 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %13, 1
@@ -870,41 +870,41 @@ func main() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %18, i64 %11, i1 true, i64 %15)
 // CHECK-NEXT:   %19 = getelementptr inbounds i8, ptr %14, i64 %11
 // CHECK-NEXT:   %20 = load i8, ptr %19, align 1
-// CHECK-NEXT:   %21 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %21 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %22 = load i64, ptr %21, align 8
 // CHECK-NEXT:   %23 = add i64 %22, 1
-// CHECK-NEXT:   %24 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %24 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %23, ptr %24, align 8
 // CHECK-NEXT:   %25 = insertvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } undef, i8 %20, 0
 // CHECK-NEXT:   %26 = insertvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } %25, %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer, 1
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %26
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).ReadRune"(ptr %0){{.*}} {
+// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).ReadRune"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %4 = load %"{{.*}}/runtime/internal/runtime.String", ptr %3, align 8
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %4, 1
 // CHECK-NEXT:   %6 = icmp sge i64 %2, %5
 // CHECK-NEXT:   br i1 %6, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   store i64 -1, ptr %7, align 8
-// CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @"{{.*}}/cl/_testgo/reader.EOF", align 8
+// CHECK-NEXT:   %8 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @main.EOF, align 8
 // CHECK-NEXT:   %9 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } { i32 0, i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %8, 2
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %11 = load i64, ptr %10, align 8
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   store i64 %11, ptr %12, align 8
-// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %14 = load i64, ptr %13, align 8
-// CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %15 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %16 = load %"{{.*}}/runtime/internal/runtime.String", ptr %15, align 8
 // CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %16, 0
 // CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %16, 1
@@ -918,10 +918,10 @@ func main() {
 // CHECK-NEXT:   br i1 %24, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %25 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %25 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %26 = load i64, ptr %25, align 8
 // CHECK-NEXT:   %27 = add i64 %26, 1
-// CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %28 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %27, ptr %28, align 8
 // CHECK-NEXT:   %29 = zext i8 %23 to i32
 // CHECK-NEXT:   %30 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i32 %29, 0
@@ -930,19 +930,19 @@ func main() {
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %32
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %33 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %33 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %34 = load %"{{.*}}/runtime/internal/runtime.String", ptr %33, align 8
-// CHECK-NEXT:   %35 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %35 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %36 = load i64, ptr %35, align 8
 // CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %34, 1
 // CHECK-NEXT:   %38 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringSlice2"(%"{{.*}}/runtime/internal/runtime.String" %34, i64 %36, i64 %37, i1 true, i1 true)
 // CHECK-NEXT:   %39 = call { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"{{.*}}/runtime/internal/runtime.String" %38)
 // CHECK-NEXT:   %40 = extractvalue { i32, i64 } %39, 0
 // CHECK-NEXT:   %41 = extractvalue { i32, i64 } %39, 1
-// CHECK-NEXT:   %42 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %42 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %43 = load i64, ptr %42, align 8
 // CHECK-NEXT:   %44 = add i64 %43, %41
-// CHECK-NEXT:   %45 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %45 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %44, ptr %45, align 8
 // CHECK-NEXT:   %46 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i32 %40, 0
 // CHECK-NEXT:   %47 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %46, i64 %41, 1
@@ -950,9 +950,9 @@ func main() {
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %48
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).Seek"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).Seek"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   store i64 -1, ptr %3, align 8
 // CHECK-NEXT:   %4 = icmp eq i64 %2, 0
 // CHECK-NEXT:   br i1 %4, label %_llgo_2, label %_llgo_4
@@ -966,7 +966,7 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %8 = load i64, ptr %7, align 8
 // CHECK-NEXT:   %9 = add i64 %8, %1
 // CHECK-NEXT:   br label %_llgo_1
@@ -976,7 +976,7 @@ func main() {
 // CHECK-NEXT:   br i1 %10, label %_llgo_3, label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %11 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %12 = load %"{{.*}}/runtime/internal/runtime.String", ptr %11, align 8
 // CHECK-NEXT:   %13 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %12, 1
 // CHECK-NEXT:   %14 = add i64 %13, %1
@@ -987,91 +987,91 @@ func main() {
 // CHECK-NEXT:   br i1 %15, label %_llgo_5, label %_llgo_7
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %16 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @57, i64 34 })
+// CHECK-NEXT:   %16 = call %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" { ptr @57, i64 34 })
 // CHECK-NEXT:   %17 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } { i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %16, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %17
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %18 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @58, i64 37 })
+// CHECK-NEXT:   %18 = call %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" { ptr @58, i64 37 })
 // CHECK-NEXT:   %19 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } { i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %18, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %19
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %20 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %20 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %5, ptr %20, align 8
 // CHECK-NEXT:   %21 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
 // CHECK-NEXT:   %22 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %21, %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %22
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/reader.(*stringReader).Size"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*stringReader).Size"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.String", ptr %1, align 8
 // CHECK-NEXT:   %3 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %2, 1
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*stringReader).UnreadByte"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.(*stringReader).UnreadByte"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
 // CHECK-NEXT:   %3 = icmp sle i64 %2, 0
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @59, i64 48 })
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" { ptr @59, i64 48 })
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   store i64 -1, ptr %5, align 8
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %7 = load i64, ptr %6, align 8
 // CHECK-NEXT:   %8 = sub i64 %7, 1
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %8, ptr %9, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*stringReader).UnreadRune"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.(*stringReader).UnreadRune"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
 // CHECK-NEXT:   %3 = icmp sle i64 %2, 0
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 49 })
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 49 })
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   %6 = load i64, ptr %5, align 8
 // CHECK-NEXT:   %7 = icmp slt i64 %6, 0
 // CHECK-NEXT:   br i1 %7, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @61, i64 62 })
+// CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.iface" @main.newError(%"{{.*}}/runtime/internal/runtime.String" { ptr @61, i64 62 })
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   %10 = load i64, ptr %9, align 8
-// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %11 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %10, ptr %11, align 8
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   store i64 -1, ptr %12, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   store i64 -1, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %4 = load i64, ptr %3, align 8
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %6 = load %"{{.*}}/runtime/internal/runtime.String", ptr %5, align 8
 // CHECK-NEXT:   %7 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %6, 1
 // CHECK-NEXT:   %8 = icmp sge i64 %4, %7
@@ -1081,13 +1081,13 @@ func main() {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } zeroinitializer
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %10 = load %"{{.*}}/runtime/internal/runtime.String", ptr %9, align 8
-// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %11 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %12 = load i64, ptr %11, align 8
 // CHECK-NEXT:   %13 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %10, 1
 // CHECK-NEXT:   %14 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringSlice2"(%"{{.*}}/runtime/internal/runtime.String" %10, i64 %12, i64 %13, i1 true, i1 true)
-// CHECK-NEXT:   %15 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.WriteString"(%"{{.*}}/runtime/internal/runtime.iface" %1, %"{{.*}}/runtime/internal/runtime.String" %14)
+// CHECK-NEXT:   %15 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.WriteString(%"{{.*}}/runtime/internal/runtime.iface" %1, %"{{.*}}/runtime/internal/runtime.String" %14)
 // CHECK-NEXT:   %16 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %15, 0
 // CHECK-NEXT:   %17 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %15, 1
 // CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %14, 1
@@ -1102,17 +1102,17 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %22 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %23 = load i64, ptr %22, align 8
 // CHECK-NEXT:   %24 = add i64 %23, %16
-// CHECK-NEXT:   %25 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %25 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %24, ptr %25, align 8
 // CHECK-NEXT:   %26 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %14, 1
 // CHECK-NEXT:   %27 = icmp ne i64 %16, %26
 // CHECK-NEXT:   br i1 %27, label %_llgo_7, label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_7
-// CHECK-NEXT:   %28 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @"{{.*}}/cl/_testgo/reader.ErrShortWrite", align 8
+// CHECK-NEXT:   %28 = load %"{{.*}}/runtime/internal/runtime.iface", ptr @main.ErrShortWrite, align 8
 // CHECK-NEXT:   br label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_7, %_llgo_4
@@ -1151,128 +1151,128 @@ func main() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).Close"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.(*nopCloserWriterTo).Close"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).Close"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.(*nopCloserWriterTo).Close"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).Read"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*nopCloserWriterTo).Read"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).Read"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*nopCloserWriterTo).Read"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*nopCloserWriterTo).WriteTo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*nopCloserWriterTo).WriteTo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Close"(ptr %0, %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @__llgo_stub.main.nopCloserWriterTo.Close(ptr %0, %main.nopCloserWriterTo %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Close"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @main.nopCloserWriterTo.Close(%main.nopCloserWriterTo %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Read"(ptr %0, %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @__llgo_stub.main.nopCloserWriterTo.Read(ptr %0, %main.nopCloserWriterTo %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Read"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.nopCloserWriterTo.Read(%main.nopCloserWriterTo %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(ptr %0, %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @__llgo_stub.main.nopCloserWriterTo.WriteTo(ptr %0, %main.nopCloserWriterTo %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.nopCloserWriterTo.WriteTo(%main.nopCloserWriterTo %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*nopCloser).Close"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.(*nopCloser).Close"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*nopCloser).Close"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.(*nopCloser).Close"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*nopCloser).Read"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*nopCloser).Read"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloser).Read"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*nopCloser).Read"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/reader.nopCloser.Close"(ptr %0, %"{{.*}}/cl/_testgo/reader.nopCloser" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @__llgo_stub.main.nopCloser.Close(ptr %0, %main.nopCloser %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloser.Close"(%"{{.*}}/cl/_testgo/reader.nopCloser" %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @main.nopCloser.Close(%main.nopCloser %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.nopCloser.Read"(ptr %0, %"{{.*}}/cl/_testgo/reader.nopCloser" %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @__llgo_stub.main.nopCloser.Read(ptr %0, %main.nopCloser %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloser.Read"(%"{{.*}}/cl/_testgo/reader.nopCloser" %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @main.nopCloser.Read(%main.nopCloser %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).Len"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*stringReader).Len"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/reader.(*stringReader).Len"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*stringReader).Len"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).Read"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*stringReader).Read"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).Read"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).Read"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).ReadAt"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2, i64 %3){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*stringReader).ReadAt"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2, i64 %3){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %4 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).ReadAt"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2, i64 %3)
+// CHECK-NEXT:   %4 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).ReadAt"(ptr %1, %"{{.*}}/runtime/internal/runtime.Slice" %2, i64 %3)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).ReadByte"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*stringReader).ReadByte"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).ReadByte"(ptr %1)
+// CHECK-NEXT:   %2 = tail call { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).ReadByte"(ptr %1)
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).ReadRune"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*stringReader).ReadRune"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).ReadRune"(ptr %1)
+// CHECK-NEXT:   %2 = tail call { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).ReadRune"(ptr %1)
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).Seek"(ptr %0, ptr %1, i64 %2, i64 %3){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*stringReader).Seek"(ptr %0, ptr %1, i64 %2, i64 %3){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %4 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).Seek"(ptr %1, i64 %2, i64 %3)
+// CHECK-NEXT:   %4 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).Seek"(ptr %1, i64 %2, i64 %3)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).Size"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*stringReader).Size"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/reader.(*stringReader).Size"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*stringReader).Size"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).UnreadByte"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.(*stringReader).UnreadByte"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*stringReader).UnreadByte"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.(*stringReader).UnreadByte"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).UnreadRune"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.(*stringReader).UnreadRune"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*stringReader).UnreadRune"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.(*stringReader).UnreadRune"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*stringReader).WriteTo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-LABEL: define linkonce { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"__llgo_stub.main.(*stringReader).WriteTo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*stringReader).WriteTo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %3 = tail call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"main.(*stringReader).WriteTo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/reader.(*errorString).Error"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.main.(*errorString).Error"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reader.(*errorString).Error"(ptr %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"main.(*errorString).Error"(ptr %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }

--- a/cl/_testgo/recoverthenpanic/in.go
+++ b/cl/_testgo/recoverthenpanic/in.go
@@ -5,7 +5,7 @@ package main
 // CHECK: @1 = private unnamed_addr constant [3 x i8] c"end", align 1
 // CHECK: @2 = private unnamed_addr constant [13 x i8] c"panic in main", align 1
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/recoverthenpanic.End"(){{.*}} {
+// CHECK-LABEL: define void @main.End(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.eface" @"{{.*}}/runtime/internal/runtime.Recover"()
 // CHECK-NEXT:   %1 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %0, %"{{.*}}/runtime/internal/runtime.eface" zeroinitializer)
@@ -20,7 +20,7 @@ package main
 // CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 2
 // CHECK-NEXT:   store ptr %3, ptr %8, align 8
 // CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 3
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.End", %_llgo_5), ptr %9, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.End, %_llgo_5), ptr %9, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %5)
 // CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 1
 // CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 3
@@ -51,7 +51,7 @@ package main
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_4
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 3 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.End", %_llgo_8), ptr %12, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.End, %_llgo_8), ptr %12, align 8
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
@@ -61,7 +61,7 @@ package main
 // CHECK-NEXT:   br i1 %2, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_7, %_llgo_2
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.End", %_llgo_6), ptr %11, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.End, %_llgo_6), ptr %11, align 8
 // CHECK-NEXT:   %23 = load i64, ptr %10, align 8
 // CHECK-NEXT:   %24 = and i64 %23, 1
 // CHECK-NEXT:   %25 = icmp ne i64 %24, 0
@@ -72,7 +72,7 @@ package main
 // CHECK-NEXT:   br label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.End", %_llgo_6), ptr %12, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.End, %_llgo_6), ptr %12, align 8
 // CHECK-NEXT:   %26 = load ptr, ptr %11, align 8
 // CHECK-NEXT:   indirectbr ptr %26, [label %_llgo_6, label %_llgo_5]
 // CHECK-EMPTY:
@@ -119,20 +119,20 @@ func main() {
 	panic("panic in main")
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/recoverthenpanic.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/recoverthenpanic.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/recoverthenpanic.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/recoverthenpanic.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()
 // CHECK-NEXT:   %1 = alloca i8, i64 {{.*}}, align 1
@@ -144,7 +144,7 @@ func main() {
 // CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 2
 // CHECK-NEXT:   store ptr %0, ptr %5, align 8
 // CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 3
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.main", %_llgo_2), ptr %6, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_2), ptr %6, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %2)
 // CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 3
@@ -159,9 +159,9 @@ func main() {
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.main", %_llgo_3), ptr %8, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_3), ptr %8, align 8
 // CHECK-NEXT:   %13 = load i64, ptr %7, align 8
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/recoverthenpanic.End"()
+// CHECK-NEXT:   call void @main.End()
 // CHECK-NEXT:   %14 = load %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, align 8
 // CHECK-NEXT:   %15 = extractvalue %"{{.*}}/runtime/internal/runtime.Defer" %14, 2
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %15)
@@ -180,7 +180,7 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.main", %_llgo_3), ptr %9, align 8
+// CHECK-NEXT:   store ptr blockaddress(@main.main, %_llgo_3), ptr %9, align 8
 // CHECK-NEXT:   %19 = load ptr, ptr %8, align 8
 // CHECK-NEXT:   indirectbr ptr %19, [label %_llgo_3, label %_llgo_2]
 // CHECK-NEXT: }

--- a/cl/_testgo/reflect/in.go
+++ b/cl/_testgo/reflect/in.go
@@ -89,31 +89,31 @@ type T struct {
 	n int
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/reflect.(*T).Add"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*T).Add"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 11 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
 // CHECK-NEXT:   %4 = add i64 %3, %1
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 %4, ptr %5, align 8
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %7 = load i64, ptr %6, align 8
 // CHECK-NEXT:   ret i64 %7
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.callClosure"(){{.*}} {
+// CHECK-LABEL: define void @main.callClosure(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 100, ptr %0, align 8
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/reflect.callClosure$1", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.callClosure$1", ptr undef }, ptr %1, 1
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { ptr, ptr } %3, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr undef }, ptr %4, 1
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %4, 1
 // CHECK-NEXT:   %6 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %5)
 // CHECK-NEXT:   %7 = call i64 @reflect.Value.Kind(%reflect.Value %6)
 // CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %6)
@@ -155,7 +155,7 @@ type T struct {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %34 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %6)
 // CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %34, 0
-// CHECK-NEXT:   %36 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %35)
+// CHECK-NEXT:   %36 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr %35)
 // CHECK-NEXT:   br i1 %36, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
@@ -188,7 +188,7 @@ type T struct {
 // CHECK-NEXT:   br i1 %48, label %_llgo_2, label %_llgo_1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/reflect.callClosure$1"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.callClosure$1"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 12 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -200,11 +200,11 @@ type T struct {
 // CHECK-NEXT:   ret i64 %6
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.callFunc"(){{.*}} {
+// CHECK-LABEL: define void @main.callFunc(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflect.callFunc$1", ptr null }, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.main.callFunc$1", ptr null }, ptr %0, align 8
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %0, 1
 // CHECK-NEXT:   %2 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %1)
 // CHECK-NEXT:   %3 = call i64 @reflect.Value.Kind(%reflect.Value %2)
 // CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %2)
@@ -246,7 +246,7 @@ type T struct {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %30 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %2)
 // CHECK-NEXT:   %31 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %30, 0
-// CHECK-NEXT:   %32 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %31)
+// CHECK-NEXT:   %32 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr %31)
 // CHECK-NEXT:   br i1 %32, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
@@ -279,7 +279,7 @@ type T struct {
 // CHECK-NEXT:   br i1 %44, label %_llgo_2, label %_llgo_1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/reflect.callFunc$1"(i64 %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.callFunc$1"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 9 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -319,12 +319,12 @@ func callMethod() {
 	println(r2[0].Int())
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.callIMethod"(){{.*}} {
+// CHECK-LABEL: define void @main.callIMethod(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", ptr @"*_llgo_{{.*}}/cl/_testgo/reflect.T")
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.T")
 // CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %4)
@@ -373,7 +373,7 @@ func callMethod() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %38 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
 // CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %38, 0
-// CHECK-NEXT:   %40 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %39)
+// CHECK-NEXT:   %40 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr %39)
 // CHECK-NEXT:   br i1 %40, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
@@ -429,12 +429,12 @@ func callMethod() {
 // CHECK-NEXT:   br i1 %70, label %_llgo_2, label %_llgo_1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.callMethod"(){{.*}} {
+// CHECK-LABEL: define void @main.callMethod(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/reflect.T", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.T", ptr undef }, ptr %0, 1
 // CHECK-NEXT:   %3 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %2)
 // CHECK-NEXT:   %4 = call %reflect.Value @reflect.Value.Method(%reflect.Value %3, i64 0)
 // CHECK-NEXT:   %5 = call i64 @reflect.Value.Kind(%reflect.Value %4)
@@ -477,7 +477,7 @@ func callMethod() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %32 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
 // CHECK-NEXT:   %33 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %32, 0
-// CHECK-NEXT:   %34 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %33)
+// CHECK-NEXT:   %34 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr %33)
 // CHECK-NEXT:   br i1 %34, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
@@ -533,11 +533,11 @@ func callMethod() {
 // CHECK-NEXT:   br i1 %64, label %_llgo_2, label %_llgo_1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.callSlice"(){{.*}} {
+// CHECK-LABEL: define void @main.callSlice(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflect.demo", ptr null }, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %0, align 8
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %0, 1
 // CHECK-NEXT:   %2 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %1)
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr %3, align 8
@@ -679,7 +679,7 @@ func callMethod() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i64 } @"{{.*}}/cl/_testgo/reflect.demo"(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, %"{{.*}}/runtime/internal/runtime.Slice" %9){{.*}} {
+// CHECK-LABEL: define { i64, i64 } @main.demo(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, %"{{.*}}/runtime/internal/runtime.Slice" %9){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %10 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %9, 1
 // CHECK-NEXT:   br label %_llgo_1
@@ -728,13 +728,13 @@ func callMethod() {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/reflect.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/reflect.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @reflect.init()
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
@@ -742,15 +742,15 @@ func callMethod() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflect.callSlice"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflect.callFunc"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflect.callClosure"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflect.callMethod"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflect.callIMethod"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflect.mapDemo1"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflect.mapDemo2"()
+// CHECK-NEXT:   call void @main.callSlice()
+// CHECK-NEXT:   call void @main.callFunc()
+// CHECK-NEXT:   call void @main.callClosure()
+// CHECK-NEXT:   call void @main.callMethod()
+// CHECK-NEXT:   call void @main.callIMethod()
+// CHECK-NEXT:   call void @main.mapDemo1()
+// CHECK-NEXT:   call void @main.mapDemo2()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -771,7 +771,7 @@ func callIMethod() {
 	println(r2[0].Int())
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.mapDemo1"(){{.*}} {
+// CHECK-LABEL: define void @main.mapDemo1(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 2)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
@@ -951,7 +951,7 @@ func mapDemo1() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.mapDemo2"(){{.*}} {
+// CHECK-LABEL: define void @main.mapDemo2(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 0, ptr %0, align 8
@@ -1152,15 +1152,15 @@ func mapDemo2() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/reflect.callFunc$1"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.callFunc$1"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/reflect.callFunc$1"(i64 %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.callFunc$1"(i64 %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/reflect.(*T).Add"(ptr %0, ptr %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*T).Add"(ptr %0, ptr %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testgo/reflect.(*T).Add"(ptr %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.(*T).Add"(ptr %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
@@ -1170,9 +1170,9 @@ func mapDemo2() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce { i64, i64 } @"__llgo_stub.{{.*}}/cl/_testgo/reflect.demo"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9, %"{{.*}}/runtime/internal/runtime.Slice" %10){{.*}} {
+// CHECK-LABEL: define linkonce { i64, i64 } @__llgo_stub.main.demo(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9, %"{{.*}}/runtime/internal/runtime.Slice" %10){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %11 = tail call { i64, i64 } @"{{.*}}/cl/_testgo/reflect.demo"(i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9, %"{{.*}}/runtime/internal/runtime.Slice" %10)
+// CHECK-NEXT:   %11 = tail call { i64, i64 } @main.demo(i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9, %"{{.*}}/runtime/internal/runtime.Slice" %10)
 // CHECK-NEXT:   ret { i64, i64 } %11
 // CHECK-NEXT: }
 

--- a/cl/_testgo/reflectfn/in.go
+++ b/cl/_testgo/reflectfn/in.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectfn.demo"(){{.*}} {
+// CHECK-LABEL: define void @main.demo(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -16,19 +16,19 @@ func demo() {
 	println("demo")
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectfn.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 100, ptr %0, align 8
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/reflectfn.main$1", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %1, 1
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %4, i64 0
 // CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { ptr, ptr } %3, ptr %6, align 8
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %6, 1
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %6, 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %7, ptr %5, align 8
 // CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %4, 0
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %8, i64 1, 1
@@ -37,8 +37,8 @@ func demo() {
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %12, i64 0
 // CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflectfn.demo", ptr null }, ptr %14, align 8
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %14, 1
+// CHECK-NEXT:   store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %14, align 8
+// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %14, 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %15, ptr %13, align 8
 // CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %12, 0
 // CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %16, i64 1, 1
@@ -47,8 +47,8 @@ func demo() {
 // CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %21 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %20, i64 0
 // CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflectfn.demo", ptr null }, ptr %22, align 8
-// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %22, 1
+// CHECK-NEXT:   store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %22, align 8
+// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %22, 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %23, ptr %21, align 8
 // CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %20, 0
 // CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %24, i64 1, 1
@@ -56,7 +56,7 @@ func demo() {
 // CHECK-NEXT:   %27 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %26)
 // CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { ptr, ptr } %3, ptr %28, align 8
-// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %28, 1
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %28, 1
 // CHECK-NEXT:   %30 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %29)
 // CHECK-NEXT:   %31 = call ptr @reflect.Value.UnsafePointer(%reflect.Value %30)
 // CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
@@ -68,8 +68,8 @@ func demo() {
 // CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %36, i64 1, 2
 // CHECK-NEXT:   %38 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %37)
 // CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflectfn.demo", ptr null }, ptr %39, align 8
-// CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %39, 1
+// CHECK-NEXT:   store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %39, align 8
+// CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %39, 1
 // CHECK-NEXT:   %41 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %40)
 // CHECK-NEXT:   %42 = call ptr @reflect.Value.UnsafePointer(%reflect.Value %41)
 // CHECK-NEXT:   %43 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
@@ -81,8 +81,8 @@ func demo() {
 // CHECK-NEXT:   %48 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %47, i64 1, 2
 // CHECK-NEXT:   %49 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %48)
 // CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflectfn.demo", ptr null }, ptr %50, align 8
-// CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %50, 1
+// CHECK-NEXT:   store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %50, align 8
+// CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %50, 1
 // CHECK-NEXT:   %52 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %51)
 // CHECK-NEXT:   %53 = call ptr @reflect.Value.UnsafePointer(%reflect.Value %52)
 // CHECK-NEXT:   %54 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)

--- a/cl/_testgo/reflectmk/in.go
+++ b/cl/_testgo/reflectmk/in.go
@@ -33,14 +33,14 @@ func (p *Point) Set(x int, y int) {
 	p.y = y
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reflectmk.Point.String"(%"{{.*}}/cl/_testgo/reflectmk.Point" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.Point.String(%main.Point %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/reflectmk.Point", align 8
+// CHECK-NEXT:   %1 = alloca %main.Point, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reflectmk.Point" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.Point %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Point, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.Point, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %5 = load i64, ptr %4, align 8
 // CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
 // CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %6, i64 0
@@ -60,11 +60,11 @@ func (p *Point) Set(x int, y int) {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %16
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectmk.(*Point).Set"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define void @"main.(*Point).Set"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 %1, ptr %3, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.Point, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i64 %2, ptr %4, align 8
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -129,22 +129,22 @@ func methodByName(name string) {
 	}
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reflectmk.(*Point).String"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.(*Point).String"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 49 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %0, align 8
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reflectmk.Point.String"(%"{{.*}}/cl/_testgo/reflectmk.Point" %2)
+// CHECK-NEXT:   %2 = load %main.Point, ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @main.Point.String(%main.Point %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectmk.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/reflectmk.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/reflectmk.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @fmt.init()
 // CHECK-NEXT:   call void @reflect.init()
 // CHECK-NEXT:   br label %_llgo_2
@@ -153,9 +153,9 @@ func methodByName(name string) {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectmk.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/reflectmk.Point", ptr null })
+// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.Point", ptr null })
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %0)
 // CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %0, 0
 // CHECK-NEXT:   %3 = getelementptr ptr, ptr %2, i64 11
@@ -492,11 +492,11 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_20:                                         ; preds = %_llgo_21
 // CHECK-NEXT:   %250 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %251 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %250, i32 0, i32 0
-// CHECK-NEXT:   %252 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %250, i32 0, i32 1
+// CHECK-NEXT:   %251 = getelementptr inbounds %main.Point, ptr %250, i32 0, i32 0
+// CHECK-NEXT:   %252 = getelementptr inbounds %main.Point, ptr %250, i32 0, i32 1
 // CHECK-NEXT:   store i64 1, ptr %251, align 8
 // CHECK-NEXT:   store i64 2, ptr %252, align 8
-// CHECK-NEXT:   %253 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/reflectmk.Point", ptr undef }, ptr %250, 1
+// CHECK-NEXT:   %253 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.Point", ptr undef }, ptr %250, 1
 // CHECK-NEXT:   %254 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %253)
 // CHECK-NEXT:   %255 = call %reflect.Value @reflect.Value.Method(%reflect.Value %254, i64 1)
 // CHECK-NEXT:   %256 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %255, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
@@ -549,19 +549,19 @@ func methodByName(name string) {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_25:                                         ; preds = %_llgo_23
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflectmk.method"(i64 1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflectmk.methodByName"(%"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
+// CHECK-NEXT:   call void @main.method(i64 1)
+// CHECK-NEXT:   call void @main.methodByName(%"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectmk.method"(i64 %0){{.*}} {
+// CHECK-LABEL: define void @main.method(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Point, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.Point, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   store i64 1, ptr %2, align 8
 // CHECK-NEXT:   store i64 2, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/reflectmk.Point", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.Point", ptr undef }, ptr %1, 1
 // CHECK-NEXT:   %5 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %4)
 // CHECK-NEXT:   %6 = call %reflect.Value @reflect.Value.Method(%reflect.Value %5, i64 %0)
 // CHECK-NEXT:   %7 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
@@ -588,14 +588,14 @@ func methodByName(name string) {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectmk.methodByName"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
+// CHECK-LABEL: define void @main.methodByName(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Point, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.Point, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   store i64 1, ptr %2, align 8
 // CHECK-NEXT:   store i64 2, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/reflectmk.Point", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.Point", ptr undef }, ptr %1, 1
 // CHECK-NEXT:   %5 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %4)
 // CHECK-NEXT:   %6 = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %5, %"{{.*}}/runtime/internal/runtime.String" %0)
 // CHECK-NEXT:   %7 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)

--- a/cl/_testgo/reflectmkfn/in.go
+++ b/cl/_testgo/reflectmkfn/in.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// CHECK-LABEL: define void @"g{{.*}}/cl/_testgo/reflectmkfn.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK: call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.FuncOf(
 // CHECK: call %reflect.Value @reflect.MakeFunc(
 // CHECK: call %"g{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(
@@ -25,7 +25,7 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define %"g{{.*}}/runtime/internal/runtime.Slice" @"g{{.*}}/cl/_testgo/reflectmkfn.main$1"(%"g{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
+// CHECK-LABEL: define %"g{{.*}}/runtime/internal/runtime.Slice" @"main.main$1"(%"g{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
 // CHECK: call %"g{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(
 // CHECK: call i64 @reflect.Value.Int(
 // CHECK: call %"g{{.*}}/runtime/internal/runtime.String" @strings.Repeat(

--- a/cl/_testgo/returnorder/in.go
+++ b/cl/_testgo/returnorder/in.go
@@ -7,11 +7,11 @@ type state struct {
 	v int
 }
 
-// CHECK-LABEL: define void @"{{.*}}returnorder.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
-	// CHECK: call { %"{{.*}}returnorder.state", i64 } @"{{.*}}returnorder.returnStateAndMut"()
-	// CHECK: extractvalue { %"{{.*}}returnorder.state", i64 } %1, 0
-	// CHECK: extractvalue { %"{{.*}}returnorder.state", i64 } %1, 1
+	// CHECK: call { %main.state, i64 } @main.returnStateAndMut()
+	// CHECK: extractvalue { %main.state, i64 } %1, 0
+	// CHECK: extractvalue { %main.state, i64 } %1, 1
 	// CHECK: icmp ne i64 %5, 2
 	// CHECK: call %"{{.*}}String" @fmt.Sprintf
 	// CHECK: call void @"{{.*}}Panic"
@@ -26,26 +26,26 @@ func main() {
 	println("ok")
 }
 
-// CHECK-LABEL: define { %"{{.*}}returnorder.state", i64 } @"{{.*}}returnorder.returnStateAndMut"(){{.*}} {
+// CHECK-LABEL: define { %main.state, i64 } @main.returnStateAndMut(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}returnorder.state", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.state, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}returnorder.(*state).mutate"(ptr %0, i64 2)
-// CHECK-NEXT:   %3 = load %"{{.*}}returnorder.state", ptr %0, align 8
-// CHECK-NEXT:   %4 = insertvalue { %"{{.*}}returnorder.state", i64 } undef, %"{{.*}}returnorder.state" %3, 0
-// CHECK-NEXT:   %5 = insertvalue { %"{{.*}}returnorder.state", i64 } %4, i64 %2, 1
-// CHECK-NEXT:   ret { %"{{.*}}returnorder.state", i64 } %5
+// CHECK-NEXT:   %2 = call i64 @"main.(*state).mutate"(ptr %0, i64 2)
+// CHECK-NEXT:   %3 = load %main.state, ptr %0, align 8
+// CHECK-NEXT:   %4 = insertvalue { %main.state, i64 } undef, %main.state %3, 0
+// CHECK-NEXT:   %5 = insertvalue { %main.state, i64 } %4, i64 %2, 1
+// CHECK-NEXT:   ret { %main.state, i64 } %5
 func returnStateAndMut() (state, int) {
 	x := state{v: 1}
 	return x, x.mutate(2)
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}returnorder.(*state).mutate"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*state).mutate"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}returnorder.state", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.state, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 %1, ptr %2, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}returnorder.state", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.state, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %4 = load i64, ptr %3, align 8
 // CHECK-NEXT:   ret i64 %4
 func (s *state) mutate(next int) int {

--- a/cl/_testgo/selects/in.go
+++ b/cl/_testgo/selects/in.go
@@ -38,20 +38,20 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/selects.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/selects.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
@@ -70,11 +70,11 @@ func main() {
 // CHECK-NEXT:   store ptr %2, ptr %9, align 8
 // CHECK-NEXT:   %10 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 2
 // CHECK-NEXT:   store ptr %4, ptr %10, align 8
-// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/selects.main$1", ptr undef }, ptr %7, 1
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %7, 1
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocRoot"(i64 16)
 // CHECK-NEXT:   %13 = getelementptr inbounds { { ptr, ptr } }, ptr %12, i32 0, i32 0
 // CHECK-NEXT:   store { ptr, ptr } %11, ptr %13, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.NewProc"(ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1", ptr %12, i64 0)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.NewProc"(ptr @"main._llgo_routine$1", ptr %12, i64 0)
 // CHECK-NEXT:   %14 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %15 = call ptr @llvm.stacksave.p0()
 // CHECK-NEXT:   %16 = alloca {}, align 8
@@ -149,7 +149,7 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.main$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.main$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { ptr, ptr, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { ptr, ptr, ptr } %1, 0
@@ -228,7 +228,7 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define ptr @"main._llgo_routine$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { { ptr, ptr } }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { { ptr, ptr } } %1, 0

--- a/cl/_testgo/sigsegv/in.go
+++ b/cl/_testgo/sigsegv/in.go
@@ -10,7 +10,7 @@ func f() *T {
 }
 
 // CHECK: ; Function Attrs: null_pointer_is_valid
-// CHECK: define void @"github.com/goplus/llgo/cl/_testgo/sigsegv.init#1"() #0 {
+// CHECK: define void @"main.init#1"() #0 {
 func init() {
 	println("init")
 	defer func() {
@@ -19,7 +19,7 @@ func init() {
 			println("recover", e.Error())
 		}
 	}()
-	// CHECK: call ptr @"github.com/goplus/llgo/cl/_testgo/sigsegv.f"()
+	// CHECK: call ptr @main.f()
 	println(f().s)
 }
 

--- a/cl/_testgo/strucintf/in.go
+++ b/cl/_testgo/strucintf/in.go
@@ -3,7 +3,7 @@ package main
 
 import "github.com/goplus/llgo/cl/_testdata/foo"
 
-// CHECK-LABEL: define %"{{.*}}eface" @"{{.*}}strucintf.Foo"(){{.*}} {
+// CHECK-LABEL: define %"{{.*}}eface" @main.Foo(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64 }, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
@@ -12,16 +12,16 @@ import "github.com/goplus/llgo/cl/_testdata/foo"
 // CHECK-NEXT:   %2 = load { i64 }, ptr %0, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store { i64 } %2, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue %"{{.*}}eface" { ptr @"{{.*}}strucintf.struct{{.*}}", ptr undef }, ptr %3, 1
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}eface" { ptr @"{{.*}}/cl/_testgo/strucintf.struct{{.*}}", ptr undef }, ptr %3, 1
 // CHECK-NEXT:   ret %"{{.*}}eface" %4
 func Foo() any {
 	return struct{ v int }{1}
 }
 
-// CHECK-LABEL: define void @"{{.*}}strucintf.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
-	// CHECK: call %"{{.*}}eface" @"{{.*}}strucintf.Foo"()
-	// CHECK: icmp eq ptr %{{[0-9]+}}, @"{{.*}}strucintf.struct{{.*}}"
+	// CHECK: call %"{{.*}}eface" @main.Foo()
+	// CHECK: icmp eq ptr %{{[0-9]+}}, @"{{.*}}/cl/_testgo/strucintf.struct{{.*}}"
 	v := Foo()
 
 	if x, ok := v.(struct{ v int }); ok {
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	// CHECK: call %"{{.*}}eface" @"{{.*}}foo.F"()
-	// CHECK: icmp eq ptr %{{[0-9]+}}, @"{{.*}}strucintf.struct{{.*}}"
+	// CHECK: icmp eq ptr %{{[0-9]+}}, @"{{.*}}/cl/_testgo/strucintf.struct{{.*}}"
 	if x, ok := foo.F().(struct{ v int }); ok {
 		// CHECK: call void @"{{.*}}PrintInt"(i64 %{{[0-9]+}})
 		// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 10)

--- a/cl/_testgo/struczero/in.go
+++ b/cl/_testgo/struczero/in.go
@@ -8,7 +8,7 @@ type bar struct {
 	f  float32
 }
 
-// CHECK-LABEL: define { %"{{.*}}foo.Foo", i1 } @"{{.*}}struczero.Bar"(%"{{.*}}eface" %0){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}foo.Foo", i1 } @main.Bar(%"{{.*}}eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}eface" %0, 0
 // CHECK-NEXT:   %2 = icmp eq ptr %1, @"_llgo_{{.*}}foo.Foo"
@@ -30,31 +30,31 @@ func Bar(v any) (ret foo.Foo, ok bool) {
 	return
 }
 
-// CHECK-LABEL: define { %"{{.*}}struczero.bar", i1 } @"{{.*}}struczero.Foo"(%"{{.*}}eface" %0){{.*}} {
+// CHECK-LABEL: define { %main.bar, i1 } @main.Foo(%"{{.*}}eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}eface" %0, 0
-// CHECK-NEXT:   %2 = icmp eq ptr %1, @"_llgo_{{.*}}struczero.bar"
+// CHECK-NEXT:   %2 = icmp eq ptr %1, @_llgo_main.bar
 // CHECK-NEXT:   br i1 %2, label %_llgo_1, label %_llgo_2
 // CHECK: _llgo_1:
 // CHECK-NEXT:   %3 = extractvalue %"{{.*}}eface" %0, 1
-// CHECK-NEXT:   %4 = load %"{{.*}}struczero.bar", ptr %3, align 8
-// CHECK-NEXT:   %5 = insertvalue { %"{{.*}}struczero.bar", i1 } undef, %"{{.*}}struczero.bar" %4, 0
-// CHECK-NEXT:   %6 = insertvalue { %"{{.*}}struczero.bar", i1 } %5, i1 true, 1
+// CHECK-NEXT:   %4 = load %main.bar, ptr %3, align 8
+// CHECK-NEXT:   %5 = insertvalue { %main.bar, i1 } undef, %main.bar %4, 0
+// CHECK-NEXT:   %6 = insertvalue { %main.bar, i1 } %5, i1 true, 1
 // CHECK: _llgo_3:
-// CHECK-NEXT:   %7 = phi { %"{{.*}}struczero.bar", i1 } [ %6, %_llgo_1 ], [ zeroinitializer, %_llgo_2 ]
-// CHECK-NEXT:   %8 = extractvalue { %"{{.*}}struczero.bar", i1 } %7, 0
-// CHECK-NEXT:   %9 = extractvalue { %"{{.*}}struczero.bar", i1 } %7, 1
-// CHECK-NEXT:   %10 = insertvalue { %"{{.*}}struczero.bar", i1 } undef, %"{{.*}}struczero.bar" %8, 0
-// CHECK-NEXT:   %11 = insertvalue { %"{{.*}}struczero.bar", i1 } %10, i1 %9, 1
-// CHECK-NEXT:   ret { %"{{.*}}struczero.bar", i1 } %11
+// CHECK-NEXT:   %7 = phi { %main.bar, i1 } [ %6, %_llgo_1 ], [ zeroinitializer, %_llgo_2 ]
+// CHECK-NEXT:   %8 = extractvalue { %main.bar, i1 } %7, 0
+// CHECK-NEXT:   %9 = extractvalue { %main.bar, i1 } %7, 1
+// CHECK-NEXT:   %10 = insertvalue { %main.bar, i1 } undef, %main.bar %8, 0
+// CHECK-NEXT:   %11 = insertvalue { %main.bar, i1 } %10, i1 %9, 1
+// CHECK-NEXT:   ret { %main.bar, i1 } %11
 func Foo(v any) (ret bar, ok bool) {
 	ret, ok = v.(bar)
 	return
 }
 
-// CHECK-LABEL: define void @"{{.*}}struczero.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
-	// CHECK: call { %"{{.*}}struczero.bar", i1 } @"{{.*}}struczero.Foo"(%"{{.*}}eface" zeroinitializer)
+	// CHECK: call { %main.bar, i1 } @main.Foo(%"{{.*}}eface" zeroinitializer)
 	// CHECK: call void @"{{.*}}PrintPointer"(ptr %{{[0-9]+}})
 	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 32)
 	// CHECK-NEXT: %{{[0-9]+}} = fpext float %{{[0-9]+}} to double
@@ -70,7 +70,7 @@ func main() {
 	// CHECK: call ptr @"{{.*}}AllocU"(i64 16)
 	// CHECK: store %"{{.*}}foo.Foo" zeroinitializer, ptr %{{[0-9]+}}, align 8
 	// CHECK: insertvalue %"{{.*}}eface" { ptr @"_llgo_{{.*}}foo.Foo", ptr undef }, ptr %{{[0-9]+}}, 1
-	// CHECK: call { %"{{.*}}foo.Foo", i1 } @"{{.*}}struczero.Bar"(%"{{.*}}eface" %{{[0-9]+}})
+	// CHECK: call { %"{{.*}}foo.Foo", i1 } @main.Bar(%"{{.*}}eface" %{{[0-9]+}})
 	// CHECK: call ptr @"{{.*}}foo.Foo.Pb"(%"{{.*}}foo.Foo" %{{[0-9]+}})
 	// CHECK: call void @"{{.*}}PrintPointer"(ptr %{{[0-9]+}})
 	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 32)

--- a/cl/_testgo/tpindex/in.go
+++ b/cl/_testgo/tpindex/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}tpindex.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 40)
 	// CHECK: store i64 1, ptr %1, align 8
@@ -9,9 +9,9 @@ func main() {
 	// CHECK: store i64 5, ptr %3, align 8
 	// CHECK: store i64 2, ptr %4, align 8
 	// CHECK: store i64 4, ptr %5, align 8
-	// CHECK: call i64 @"{{.*}}tpindex.index[int]"(%"{{.*}}Slice" %8, i64 3)
+	// CHECK: call i64 @"main.index[int]"(%"{{.*}}Slice" %8, i64 3)
 	// CHECK: call void @"{{.*}}PrintInt"(i64 %9)
-	// CHECK: call i64 @"{{.*}}tpindex.index[int]"(%"{{.*}}Slice" %8, i64 6)
+	// CHECK: call i64 @"main.index[int]"(%"{{.*}}Slice" %8, i64 6)
 	// CHECK: call void @"{{.*}}PrintInt"(i64 %10)
 	// CHECK: ret void
 	s := []int{1, 3, 5, 2, 4}
@@ -21,7 +21,7 @@ func main() {
 
 // The index function returns the index of the first occurrence of v in s,
 // or -1 if not present.
-// CHECK-LABEL: define linkonce i64 @"{{.*}}tpindex.index[int]"(%"{{.*}}Slice" %0, i64 %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"main.index[int]"(%"{{.*}}Slice" %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = extractvalue %"{{.*}}Slice" %0, 1
 // CHECK-NEXT:   br label %_llgo_1

--- a/cl/_testgo/tpinst/main.go
+++ b/cl/_testgo/tpinst/main.go
@@ -2,7 +2,7 @@
 package main
 
 // CHECK-NOT: @6 = private unnamed_addr constant [5 x i8] c"value", align 1
-// CHECK: @6 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/tpinst.value", align 1
+// CHECK: @6 = private unnamed_addr constant [10 x i8] c"main.value", align 1
 // CHECK: {{^}}@8 = private unnamed_addr constant [5 x i8] c"error", align 1{{$}}
 // CHECK: {{^}}@15 = private unnamed_addr constant [22 x i8] c"interface{value() int}", align 1{{$}}
 // CHECK: {{^}}@16 = private unnamed_addr constant [5 x i8] c"value", align 1{{$}}
@@ -15,12 +15,12 @@ type I[T interface{}] interface {
 	Value() T
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tpinst.demo"(){{.*}} {
+// CHECK-LABEL: define void @main.demo(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tpinst.M[int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %"main.M[int]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8", ptr @"*_llgo_{{.*}}/cl/_testgo/tpinst.M[int]")
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.M[int]")
 // CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
@@ -44,9 +44,9 @@ type I[T interface{}] interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testgo/tpinst.M[float64]", ptr %17, i32 0, i32 0
+// CHECK-NEXT:   %18 = getelementptr inbounds %"main.M[float64]", ptr %17, i32 0, i32 0
 // CHECK-NEXT:   store double 1.001000e+02, ptr %18, align 8
-// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$2dxw6yZ6V86Spb7J0dTDIoWqg7ba7UDXlAlpJv3-HLk", ptr @"*_llgo_{{.*}}/cl/_testgo/tpinst.M[float64]")
+// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.M[float64]")
 // CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %19, 0
 // CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %20, ptr %17, 1
 // CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %21)
@@ -70,7 +70,7 @@ type I[T interface{}] interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %4)
-// CHECK-NEXT:   %35 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"{{.*}}/cl/_testgo/tpinst.iface$2sV9fFeqOv1SzesvwIdhTqCFzDT8ZX5buKUSAoHNSww", ptr %34)
+// CHECK-NEXT:   %35 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"{{.*}}/cl/_testgo/tpinst.iface${{[-A-Za-z0-9_]+}}", ptr %34)
 // CHECK-NEXT:   br i1 %35, label %_llgo_7, label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_7
@@ -85,7 +85,7 @@ type I[T interface{}] interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_4
 // CHECK-NEXT:   %38 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 1
-// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/tpinst.iface$2sV9fFeqOv1SzesvwIdhTqCFzDT8ZX5buKUSAoHNSww", ptr %34)
+// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/tpinst.iface${{[-A-Za-z0-9_]+}}", ptr %34)
 // CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %39, 0
 // CHECK-NEXT:   %41 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %40, ptr %38, 1
 // CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %41)
@@ -105,13 +105,13 @@ type I[T interface{}] interface {
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tpinst.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/tpinst.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/tpinst.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -136,9 +136,9 @@ func demo() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tpinst.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/tpinst.demo"()
+// CHECK-NEXT:   call void @main.demo()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -154,16 +154,16 @@ func (pt *M[T]) value() T {
 	return pt.v
 }
 
-// CHECK-LABEL: define linkonce i64 @"{{.*}}/cl/_testgo/tpinst.(*M[int]).Value"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"main.(*M[int]).Value"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tpinst.M[int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %"main.M[int]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"{{.*}}/cl/_testgo/tpinst.(*M[int]).value"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"main.(*M[int]).value"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tpinst.M[int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %"main.M[int]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
@@ -174,15 +174,15 @@ func (pt *M[T]) value() T {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/tpinst.(*M[int]).Value"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*M[int]).Value"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/tpinst.(*M[int]).Value"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*M[int]).Value"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/tpinst.(*M[int]).value"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*M[int]).value"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/tpinst.(*M[int]).value"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*M[int]).value"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
@@ -192,16 +192,16 @@ func (pt *M[T]) value() T {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce double @"{{.*}}/cl/_testgo/tpinst.(*M[float64]).Value"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce double @"main.(*M[float64]).Value"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tpinst.M[float64]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %"main.M[float64]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load double, ptr %1, align 8
 // CHECK-NEXT:   ret double %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce double @"{{.*}}/cl/_testgo/tpinst.(*M[float64]).value"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce double @"main.(*M[float64]).value"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tpinst.M[float64]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %"main.M[float64]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load double, ptr %1, align 8
 // CHECK-NEXT:   ret double %2
 // CHECK-NEXT: }
@@ -212,14 +212,14 @@ func (pt *M[T]) value() T {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce double @"__llgo_stub.{{.*}}/cl/_testgo/tpinst.(*M[float64]).Value"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce double @"__llgo_stub.main.(*M[float64]).Value"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call double @"{{.*}}/cl/_testgo/tpinst.(*M[float64]).Value"(ptr %1)
+// CHECK-NEXT:   %2 = tail call double @"main.(*M[float64]).Value"(ptr %1)
 // CHECK-NEXT:   ret double %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce double @"__llgo_stub.{{.*}}/cl/_testgo/tpinst.(*M[float64]).value"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce double @"__llgo_stub.main.(*M[float64]).value"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call double @"{{.*}}/cl/_testgo/tpinst.(*M[float64]).value"(ptr %1)
+// CHECK-NEXT:   %2 = tail call double @"main.(*M[float64]).value"(ptr %1)
 // CHECK-NEXT:   ret double %2
 // CHECK-NEXT: }

--- a/cl/_testgo/tplocaltype/in.go
+++ b/cl/_testgo/tplocaltype/in.go
@@ -1,28 +1,28 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}tplocaltype.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i64 @"{{.*}}tplocaltype.use1"()
-// CHECK-NEXT:   %1 = call i64 @"{{.*}}tplocaltype.use2"()
+// CHECK-NEXT:   %0 = call i64 @main.use1()
+// CHECK-NEXT:   %1 = call i64 @main.use2()
 // CHECK-NEXT:   ret void
 func main() {
 	_ = use1()
 	_ = use2()
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}tplocaltype.use1"(){{.*}} {
+// CHECK-LABEL: define i64 @main.use1(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i64 @"{{.*}}tplocaltype.id[{{.*}}T.1.0]"(i64 1)
+// CHECK-NEXT:   %0 = call i64 @"main.id[{{.*}}T.1.0]"(i64 1)
 // CHECK-NEXT:   ret i64 %0
 func use1() int {
 	type T int
 	return int(id[T](1))
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}tplocaltype.use2"(){{.*}} {
+// CHECK-LABEL: define i64 @main.use2(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i64 @"{{.*}}tplocaltype.id[{{.*}}T.2.0]"(i64 2)
+// CHECK-NEXT:   %0 = call i64 @"main.id[{{.*}}T.2.0]"(i64 2)
 // CHECK-NEXT:   ret i64 %0
 func use2() int {
 	type T int
@@ -33,10 +33,10 @@ func id[T ~int](v T) T {
 	return v
 }
 
-// CHECK-LABEL: define linkonce i64 @"{{.*}}tplocaltype.id[{{.*}}T.1.0]"(i64 %0){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"main.id[{{.*}}T.1.0]"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret i64 %0
 
-// CHECK-LABEL: define linkonce i64 @"{{.*}}tplocaltype.id[{{.*}}T.2.0]"(i64 %0){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"main.id[{{.*}}T.2.0]"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret i64 %0

--- a/cl/_testgo/tpnamed/in.go
+++ b/cl/_testgo/tpnamed/in.go
@@ -6,32 +6,32 @@ type Future[T any] func() T
 
 type IO[T any] func() Future[T]
 
-// CHECK-LABEL: define %"{{.*}}/cl/_testgo/tpnamed.IO[error]" @"{{.*}}/cl/_testgo/tpnamed.WriteFile"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
+// CHECK-LABEL: define %"main.IO[error]" @main.WriteFile(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.IO[error]" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.WriteFile$1", ptr null }
+// CHECK-NEXT:   ret %"main.IO[error]" { ptr @"__llgo_stub.main.WriteFile$1", ptr null }
 // CHECK-NEXT: }
 
 func WriteFile(fileName string) IO[error] {
 
-	// CHECK-LABEL: define %"{{.*}}/cl/_testgo/tpnamed.Future[error]" @"{{.*}}/cl/_testgo/tpnamed.WriteFile$1"(){{.*}} {
+	// CHECK-LABEL: define %"main.Future[error]" @"main.WriteFile$1"(){{.*}} {
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future[error]" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.WriteFile$1$1", ptr null }
+	// CHECK-NEXT:   ret %"main.Future[error]" { ptr @"__llgo_stub.main.WriteFile$1$1", ptr null }
 	// CHECK-NEXT: }
 
 	return func() Future[error] {
 
-		// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/tpnamed.WriteFile$1$1"(){{.*}} {
+		// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"main.WriteFile$1$1"(){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer
 		// CHECK-NEXT: }
 
-		// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tpnamed.init"(){{.*}} {
+		// CHECK-LABEL: define void @main.init(){{.*}} {
 		// CHECK-NEXT: _llgo_0:
-		// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/tpnamed.init$guard", align 1
+		// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 		// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 		// CHECK-EMPTY:
 		// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-		// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/tpnamed.init$guard", align 1
+		// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 		// CHECK-NEXT:   br label %_llgo_2
 		// CHECK-EMPTY:
 		// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -44,22 +44,22 @@ func WriteFile(fileName string) IO[error] {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tpnamed.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:  %0 = call [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.RunIO{{\[\[0\]byte\]}}"(%"{{.*}}/cl/_testgo/tpnamed.IO{{\[\[0\]byte\]}}" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1", ptr null })
+// CHECK-NEXT:  %0 = call [0 x i8] @"main.RunIO{{\[\[0\]byte\]}}"(%"main.IO{{\[\[0\]byte\]}}" { ptr @"__llgo_stub.main.main$1", ptr null })
 // CHECK-NEXT:  ret void
 // CHECK-NEXT: }
 
 func main() {
 
-	// CHECK-LABEL: define %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" @"{{.*}}/cl/_testgo/tpnamed.main$1"()
+	// CHECK-LABEL: define %"main.Future{{\[\[0\]byte\]}}" @"main.main$1"()
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1$1", ptr null }
+	// CHECK-NEXT:   ret %"main.Future{{\[\[0\]byte\]}}" { ptr @"__llgo_stub.main.main$1$1", ptr null }
 	// CHECK-NEXT: }
 
 	RunIO[Void](func() Future[Void] {
 
-		// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.main$1$1"(){{.*}} {
+		// CHECK-LABEL: define [0 x i8] @"main.main$1$1"(){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   ret [0 x i8] zeroinitializer
 		// CHECK-NEXT: }
@@ -74,39 +74,39 @@ func RunIO[T any](call IO[T]) T {
 	return call()()
 }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/cl/_testgo/tpnamed.Future[error]" @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.WriteFile$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce %"main.Future[error]" @"__llgo_stub.main.WriteFile$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = tail call %"{{.*}}/cl/_testgo/tpnamed.Future[error]" @"{{.*}}/cl/_testgo/tpnamed.WriteFile$1"()
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future[error]" %1
+// CHECK-NEXT:   %1 = tail call %"main.Future[error]" @"main.WriteFile$1"()
+// CHECK-NEXT:   ret %"main.Future[error]" %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.WriteFile$1$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.main.WriteFile$1$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/tpnamed.WriteFile$1$1"()
+// CHECK-NEXT:   %1 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"main.WriteFile$1$1"()
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce %"main.Future{{\[\[0\]byte\]}}" @"__llgo_stub.main.main$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = tail call %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" @"{{.*}}/cl/_testgo/tpnamed.main$1"()
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" %1
+// CHECK-NEXT:   %1 = tail call %"main.Future{{\[\[0\]byte\]}}" @"main.main$1"()
+// CHECK-NEXT:   ret %"main.Future{{\[\[0\]byte\]}}" %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.RunIO{{\[\[0\]byte\]}}"(%"{{.*}}/cl/_testgo/tpnamed.IO{{\[\[0\]byte\]}}" %0){{.*}} {
+// CHECK-LABEL: define linkonce [0 x i8] @"main.RunIO{{\[\[0\]byte\]}}"(%"main.IO{{\[\[0\]byte\]}}" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.IO{{\[\[0\]byte\]}}" %0, 1
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.IO{{\[\[0\]byte\]}}" %0, 0
-// CHECK-NEXT:   %3 = call %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" %2(ptr %1)
-// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" %3, 1
-// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" %3, 0
+// CHECK-NEXT:   %1 = extractvalue %"main.IO{{\[\[0\]byte\]}}" %0, 1
+// CHECK-NEXT:   %2 = extractvalue %"main.IO{{\[\[0\]byte\]}}" %0, 0
+// CHECK-NEXT:   %3 = call %"main.Future{{\[\[0\]byte\]}}" %2(ptr %1)
+// CHECK-NEXT:   %4 = extractvalue %"main.Future{{\[\[0\]byte\]}}" %3, 1
+// CHECK-NEXT:   %5 = extractvalue %"main.Future{{\[\[0\]byte\]}}" %3, 0
 // CHECK-NEXT:   %6 = icmp eq ptr %5, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %6)
 // CHECK-NEXT:   %7 = call [0 x i8] %5(ptr %4)
 // CHECK-NEXT:   ret [0 x i8] %7
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce [0 x i8] @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce [0 x i8] @"__llgo_stub.main.main$1$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = tail call [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.main$1$1"()
+// CHECK-NEXT:   %1 = tail call [0 x i8] @"main.main$1$1"()
 // CHECK-NEXT:   ret [0 x i8] %1
 // CHECK-NEXT: }

--- a/cl/_testgo/tprecur/in.go
+++ b/cl/_testgo/tprecur/in.go
@@ -14,28 +14,28 @@ func recursive() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tprecur.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/tprecur.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/tprecur.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tprecur.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/tprecur.recursive"()
+// CHECK-NEXT:   call void @main.recursive()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tprecur.recursive"(){{.*}} {
+// CHECK-LABEL: define void @main.recursive(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i64 @"{{.*}}/cl/_testgo/tprecur.recur1[{{.*}}/cl/_testgo/tprecur.T.1.0]"(i64 5)
+// CHECK-NEXT:   %0 = call i64 @"main.recur1[main.T.1.0]"(i64 5)
 // CHECK-NEXT:   %1 = icmp ne i64 %0, 110
 // CHECK-NEXT:   br i1 %1, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
@@ -74,7 +74,7 @@ func recur2[T Integer](n T) T {
 	return sum + recur1(n-1)
 }
 
-// CHECK-LABEL: define linkonce i64 @"{{.*}}/cl/_testgo/tprecur.recur1[{{.*}}/cl/_testgo/tprecur.T.1.0]"(i64 %0){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"main.recur1[main.T.1.0]"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq i64 %0, 0
 // CHECK-NEXT:   br i1 %1, label %_llgo_1, label %_llgo_3
@@ -84,7 +84,7 @@ func recur2[T Integer](n T) T {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_3
 // CHECK-NEXT:   %2 = sub i64 %0, 1
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/tprecur.recur2[{{.*}}/cl/_testgo/tprecur.T.1.0]"(i64 %2)
+// CHECK-NEXT:   %3 = call i64 @"main.recur2[main.T.1.0]"(i64 %2)
 // CHECK-NEXT:   %4 = mul i64 %0, %3
 // CHECK-NEXT:   ret i64 %4
 // CHECK-EMPTY:
@@ -93,7 +93,7 @@ func recur2[T Integer](n T) T {
 // CHECK-NEXT:   br i1 %5, label %_llgo_1, label %_llgo_2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"{{.*}}/cl/_testgo/tprecur.recur2[{{.*}}/cl/_testgo/tprecur.T.1.0]"(i64 %0){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"main.recur2[main.T.1.0]"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.MakeSlice"(i64 %0, i64 %0, i64 8)
 // CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 1
@@ -142,7 +142,7 @@ func recur2[T Integer](n T) T {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_4
 // CHECK-NEXT:   %26 = sub i64 %0, 1
-// CHECK-NEXT:   %27 = call i64 @"{{.*}}/cl/_testgo/tprecur.recur1[{{.*}}/cl/_testgo/tprecur.T.1.0]"(i64 %26)
+// CHECK-NEXT:   %27 = call i64 @"main.recur1[main.T.1.0]"(i64 %26)
 // CHECK-NEXT:   %28 = add i64 %14, %27
 // CHECK-NEXT:   ret i64 %28
 // CHECK-NEXT: }

--- a/cl/_testgo/tprecurfn/in.go
+++ b/cl/_testgo/tprecurfn/in.go
@@ -6,17 +6,17 @@ type My[T any] struct {
 	next *My[T]
 }
 
-// CHECK-LABEL: define void @"{{.*}}tprecurfn.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK:  %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-	// CHECK-NEXT:  %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tprecurfn.My[int]", ptr %0, i32 0, i32 1
+	// CHECK-NEXT:  %1 = getelementptr inbounds %"main.My[int]", ptr %0, i32 0, i32 1
 	// CHECK-NEXT:  %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-	// CHECK-NEXT:  %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/tprecurfn.My[int]", ptr %2, i32 0, i32 0
-	// CHECK-NEXT:  store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tprecurfn.main$1", ptr null }, ptr %3, align 8
+	// CHECK-NEXT:  %3 = getelementptr inbounds %"main.My[int]", ptr %2, i32 0, i32 0
+	// CHECK-NEXT:  store { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null }, ptr %3, align 8
 	// CHECK-NEXT:  store ptr %2, ptr %1, align 8
-	// CHECK-NEXT:  %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/tprecurfn.My[int]", ptr %0, i32 0, i32 1
+	// CHECK-NEXT:  %4 = getelementptr inbounds %"main.My[int]", ptr %0, i32 0, i32 1
 	// CHECK-NEXT:  %5 = load ptr, ptr %4, align 8
-	// CHECK-NEXT:  %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/tprecurfn.My[int]", ptr %5, i32 0, i32 0
+	// CHECK-NEXT:  %6 = getelementptr inbounds %"main.My[int]", ptr %5, i32 0, i32 0
 	// CHECK-NEXT:  %7 = load { ptr, ptr }, ptr %6, align 8
 	// CHECK-NEXT:  %8 = extractvalue { ptr, ptr } %7, 1
 	// CHECK-NEXT:  %9 = extractvalue { ptr, ptr } %7, 0
@@ -27,7 +27,7 @@ func main() {
 	m.next.fn(100)
 }
 
-// CHECK-LABEL: define void @"{{.*}}tprecurfn.main$1"(i64 %0){{.*}} {
+// CHECK-LABEL: define void @"main.main$1"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}PrintInt"(i64 %0)
 // CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)

--- a/cl/_testgo/tptypes/in.go
+++ b/cl/_testgo/tptypes/in.go
@@ -3,13 +3,13 @@ package main
 
 // CHECK: {{^}}@0 = private unnamed_addr constant [5 x i8] c"hello", align 1{{$}}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tptypes.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/tptypes.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/tptypes.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -53,38 +53,38 @@ type (
 	SliceString = Slice[[]string, string]
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tptypes.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/tptypes.Data[int]", align 8
+// CHECK-NEXT:   %0 = alloca %"main.Data[int]", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Data[int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %"main.Data[int]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/tptypes.Data[int]", ptr %0, align 8
-// CHECK-NEXT:   %3 = extractvalue %"{{.*}}/cl/_testgo/tptypes.Data[int]" %2, 0
+// CHECK-NEXT:   %2 = load %"main.Data[int]", ptr %0, align 8
+// CHECK-NEXT:   %3 = extractvalue %"main.Data[int]" %2, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %4 = alloca %"{{.*}}/cl/_testgo/tptypes.Data[string]", align 8
+// CHECK-NEXT:   %4 = alloca %"main.Data[string]", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %4, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Data[string]", ptr %4, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %"main.Data[string]", ptr %4, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
-// CHECK-NEXT:   %6 = load %"{{.*}}/cl/_testgo/tptypes.Data[string]", ptr %4, align 8
-// CHECK-NEXT:   %7 = extractvalue %"{{.*}}/cl/_testgo/tptypes.Data[string]" %6, 0
+// CHECK-NEXT:   %6 = load %"main.Data[string]", ptr %4, align 8
+// CHECK-NEXT:   %7 = extractvalue %"main.Data[string]" %6, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %7)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %8 = alloca %"{{.*}}/cl/_testgo/tptypes.Data[int]", align 8
+// CHECK-NEXT:   %8 = alloca %"main.Data[int]", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %8, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Data[int]", ptr %8, i32 0, i32 0
+// CHECK-NEXT:   %9 = getelementptr inbounds %"main.Data[int]", ptr %8, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %9, align 8
-// CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testgo/tptypes.Data[int]", ptr %8, align 8
-// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/cl/_testgo/tptypes.Data[int]" %10, 0
+// CHECK-NEXT:   %10 = load %"main.Data[int]", ptr %8, align 8
+// CHECK-NEXT:   %11 = extractvalue %"main.Data[int]" %10, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %11)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %12 = alloca %"{{.*}}/cl/_testgo/tptypes.Data[string]", align 8
+// CHECK-NEXT:   %12 = alloca %"main.Data[string]", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %12, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Data[string]", ptr %12, i32 0, i32 0
+// CHECK-NEXT:   %13 = getelementptr inbounds %"main.Data[string]", ptr %12, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %13, align 8
-// CHECK-NEXT:   %14 = load %"{{.*}}/cl/_testgo/tptypes.Data[string]", ptr %12, align 8
-// CHECK-NEXT:   %15 = extractvalue %"{{.*}}/cl/_testgo/tptypes.Data[string]" %14, 0
+// CHECK-NEXT:   %14 = load %"main.Data[string]", ptr %12, align 8
+// CHECK-NEXT:   %15 = extractvalue %"main.Data[string]" %14, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %15)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 0)
@@ -96,7 +96,7 @@ type (
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %17, 0
 // CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %19, i64 1, 1
 // CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %20, i64 1, 2
-// CHECK-NEXT:   %22 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %16, %"{{.*}}/runtime/internal/runtime.Slice" %21)
+// CHECK-NEXT:   %22 = call %"{{.*}}/runtime/internal/runtime.Slice" @"main.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %16, %"{{.*}}/runtime/internal/runtime.Slice" %21)
 // CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %25 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %24, i64 0
@@ -104,7 +104,7 @@ type (
 // CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %24, 0
 // CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %26, i64 1, 1
 // CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %27, i64 1, 2
-// CHECK-NEXT:   %29 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]string,string\]}}).Append"(ptr %23, %"{{.*}}/runtime/internal/runtime.Slice" %28)
+// CHECK-NEXT:   %29 = call %"{{.*}}/runtime/internal/runtime.Slice" @"main.(*Slice{{\[\[\]string,string\]}}).Append"(ptr %23, %"{{.*}}/runtime/internal/runtime.Slice" %28)
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
 // CHECK-NEXT:   %32 = getelementptr inbounds i64, ptr %31, i64 0
@@ -118,7 +118,7 @@ type (
 // CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %31, 0
 // CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %36, i64 4, 1
 // CHECK-NEXT:   %38 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %37, i64 4, 2
-// CHECK-NEXT:   %39 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %30, %"{{.*}}/runtime/internal/runtime.Slice" %38)
+// CHECK-NEXT:   %39 = call %"{{.*}}/runtime/internal/runtime.Slice" @"main.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %30, %"{{.*}}/runtime/internal/runtime.Slice" %38)
 // CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
 // CHECK-NEXT:   %41 = getelementptr inbounds i64, ptr %40, i64 0
 // CHECK-NEXT:   store i64 1, ptr %41, align 8
@@ -131,10 +131,10 @@ type (
 // CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %40, 0
 // CHECK-NEXT:   %46 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %45, i64 4, 1
 // CHECK-NEXT:   %47 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %46, i64 4, 2
-// CHECK-NEXT:   %48 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append2"(ptr %30, %"{{.*}}/runtime/internal/runtime.Slice" %47)
-// CHECK-NEXT:   %49 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %16, i32 0, i32 0
+// CHECK-NEXT:   %48 = call %"{{.*}}/runtime/internal/runtime.Slice" @"main.(*Slice{{\[\[\]int,int\]}}).Append2"(ptr %30, %"{{.*}}/runtime/internal/runtime.Slice" %47)
+// CHECK-NEXT:   %49 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %16, i32 0, i32 0
 // CHECK-NEXT:   %50 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %49, align 8
-// CHECK-NEXT:   %51 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %16, i32 0, i32 0
+// CHECK-NEXT:   %51 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %16, i32 0, i32 0
 // CHECK-NEXT:   %52 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %51, align 8
 // CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %52, 0
 // CHECK-NEXT:   %54 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %52, 1
@@ -146,9 +146,9 @@ type (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %57)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %58 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %23, i32 0, i32 0
+// CHECK-NEXT:   %58 = getelementptr inbounds %"main.Slice{{\[\[\]string,string\]}}", ptr %23, i32 0, i32 0
 // CHECK-NEXT:   %59 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %58, align 8
-// CHECK-NEXT:   %60 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %23, i32 0, i32 0
+// CHECK-NEXT:   %60 = getelementptr inbounds %"main.Slice{{\[\[\]string,string\]}}", ptr %23, i32 0, i32 0
 // CHECK-NEXT:   %61 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %60, align 8
 // CHECK-NEXT:   %62 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %61, 0
 // CHECK-NEXT:   %63 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %61, 1
@@ -160,9 +160,9 @@ type (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %66)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %67 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %30, i32 0, i32 0
+// CHECK-NEXT:   %67 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %30, i32 0, i32 0
 // CHECK-NEXT:   %68 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %67, align 8
-// CHECK-NEXT:   %69 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %30, i32 0, i32 0
+// CHECK-NEXT:   %69 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %30, i32 0, i32 0
 // CHECK-NEXT:   %70 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %69, align 8
 // CHECK-NEXT:   %71 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %70, 0
 // CHECK-NEXT:   %72 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %70, 1
@@ -202,44 +202,44 @@ func main() {
 	println(v3.Data, v3.Data[0])
 }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"main.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %2, align 8
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 0
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 1
 // CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 8)
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %6, ptr %7, align 8
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %8, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]string,string\]}}).Append"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"main.(*Slice{{\[\[\]string,string\]}}).Append"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %2, align 8
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 0
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 1
 // CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 16)
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %"main.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %6, ptr %7, align 8
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %"main.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %8, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append2"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"main.(*Slice{{\[\[\]int,int\]}}).Append2"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %2, align 8
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 0
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 1
 // CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 8)
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %6, ptr %7, align 8
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %"main.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %8, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %9
 // CHECK-NEXT: }

--- a/cl/_testgo/typerecur/in.go
+++ b/cl/_testgo/typerecur/in.go
@@ -9,18 +9,18 @@ type counter struct {
 	state stateFn
 }
 
-// CHECK-LABEL: define %"{{.*}}typerecur.stateFn" @"{{.*}}typerecur.countState"(ptr %0){{.*}} {
+// CHECK-LABEL: define %main.stateFn @main.countState(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}typerecur.counter", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.counter, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
 // CHECK-NEXT:   %3 = add i64 %2, 1
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}typerecur.counter", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.counter, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 %3, ptr %4, align 8
 // CHECK: call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @0, i64 6 })
 // CHECK: call void @"{{.*}}PrintInt"(i64 %6)
 // CHECK: icmp sge i64 %8, %10
-// CHECK: ret %"{{.*}}typerecur.stateFn" zeroinitializer
-// CHECK: ret %"{{.*}}typerecur.stateFn" { ptr @"__llgo_stub.{{.*}}typerecur.countState", ptr null }
+// CHECK: ret %main.stateFn zeroinitializer
+// CHECK: ret %main.stateFn { ptr @__llgo_stub.main.countState, ptr null }
 func countState(c *counter) stateFn {
 	c.value++
 	println("count:", c.value)
@@ -31,13 +31,13 @@ func countState(c *counter) stateFn {
 	return countState
 }
 
-// CHECK-LABEL: define void @"{{.*}}typerecur.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 32)
 	// CHECK: store i64 5, ptr %1, align 8
-	// CHECK: store %"{{.*}}typerecur.stateFn" { ptr @"__llgo_stub.{{.*}}typerecur.countState", ptr null }, ptr %2, align 8
-	// CHECK: call %"{{.*}}typerecur.stateFn" %6(ptr %5, ptr %0)
-	// CHECK: store %"{{.*}}typerecur.stateFn" %7, ptr %8, align 8
+	// CHECK: store %main.stateFn { ptr @__llgo_stub.main.countState, ptr null }, ptr %2, align 8
+	// CHECK: call %main.stateFn %6(ptr %5, ptr %0)
+	// CHECK: store %main.stateFn %7, ptr %8, align 8
 	// CHECK: icmp ne ptr %11, null
 	// CHECK: br i1 %12, label %_llgo_1, label %_llgo_2
 	c := &counter{max: 5, state: countState}

--- a/cl/_testlibc/allocacstrs/in.go
+++ b/cl/_testlibc/allocacstrs/in.go
@@ -3,7 +3,7 @@ package main
 
 import "github.com/goplus/lib/c"
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibc/allocacstrs.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 48)

--- a/cl/_testlibc/argv/in.go
+++ b/cl/_testlibc/argv/in.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibc/argv.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   br label %_llgo_1

--- a/cl/_testlibc/atomic/in.go
+++ b/cl/_testlibc/atomic/in.go
@@ -6,7 +6,7 @@ import (
 	"github.com/goplus/lib/c/sync/atomic"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibc/atomic.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	var v int64
 

--- a/cl/_testlibc/demangle/in.go
+++ b/cl/_testlibc/demangle/in.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CHECK: @0 = private unnamed_addr constant [29 x i8] c"__ZNK9INIReader10ParseErrorEv", align 1
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibc/demangle.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	mangledName := "__ZNK9INIReader10ParseErrorEv"
 	// CHECK:  %0 = call ptr @_ZN4llvm15itaniumDemangleENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEb(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 29 }, i1 true)

--- a/cl/_testlibc/sqlite/in.go
+++ b/cl/_testlibc/sqlite/in.go
@@ -6,7 +6,7 @@ import (
 	"github.com/goplus/lib/c/sqlite"
 )
 
-// CHECK: define void @"{{.*}}/cl/_testlibc/sqlite.check"
+// CHECK: define void @main.check
 func check(err sqlite.Errno) {
 	if err != sqlite.OK {
 		// CHECK: %2 = call ptr @sqlite3_errstr(i32 %0)
@@ -15,7 +15,7 @@ func check(err sqlite.Errno) {
 	}
 }
 
-// CHECK: define void @"{{.*}}/cl/_testlibc/sqlite.main"
+// CHECK: define void @main.main
 func main() {
 	// CHECK: %0 = call { ptr, i32 } @"github.com/goplus/lib/c/sqlite.OpenV2"(ptr @1, i32 130, ptr null)
 	db, err := sqlite.OpenV2(c.Str(":memory:"), sqlite.OpenReadWrite|sqlite.OpenMemory, nil)

--- a/cl/_testlibgo/atomic/in.go
+++ b/cl/_testlibgo/atomic/in.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/atomic.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	var v int64
 

--- a/cl/_testlibgo/bytes/in.go
+++ b/cl/_testlibgo/bytes/in.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/bytes.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
 // CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.StringToBytes"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 6 })

--- a/cl/_testlibgo/complex/in.go
+++ b/cl/_testlibgo/complex/in.go
@@ -5,7 +5,7 @@ import (
 	"math/cmplx"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/complex.f"({ double, double } %0, { double, double } %1){{.*}} {
+// CHECK-LABEL: define void @main.f({ double, double } %0, { double, double } %1){{.*}} {
 func f(c, z complex128) {
 	// CHECK: %2 = call double @"math/cmplx.Abs"({ double, double } %0)
 	println("abs(3+4i):", cmplx.Abs(c))
@@ -15,12 +15,12 @@ func f(c, z complex128) {
 	println("imag(3+4i):", imag(z))
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/complex.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	re := 3.0
 	im := 4.0
 	z := 3 + 4i
 	c := complex(re, im)
-	// CHECK: call void @"{{.*}}/cl/_testlibgo/complex.f"({ double, double } { double 3.000000e+00, double 4.000000e+00 }, { double, double } { double 3.000000e+00, double 4.000000e+00 })
+	// CHECK: call void @main.f({ double, double } { double 3.000000e+00, double 4.000000e+00 }, { double, double } { double 3.000000e+00, double 4.000000e+00 })
 	f(c, z)
 }

--- a/cl/_testlibgo/deferpanic/in.go
+++ b/cl/_testlibgo/deferpanic/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK: define void @"{{.*}}/deferpanic.main"(){{.*}} {
+// CHECK: define void @main.main(){{.*}} {
 func main() {
 	defer func() {
 		e := recover()

--- a/cl/_testlibgo/errors/in.go
+++ b/cl/_testlibgo/errors/in.go
@@ -3,7 +3,7 @@ package main
 
 import "errors"
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/errors.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.iface" @errors.New(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 })
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %0)

--- a/cl/_testlibgo/math/in.go
+++ b/cl/_testlibgo/math/in.go
@@ -5,7 +5,7 @@ import (
 	"math"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/math.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: %0 = call double @math.Sqrt(double 2.000000e+00)
 	// CHECK: %1 = call double @math.Abs(double -1.200000e+00)

--- a/cl/_testlibgo/mathbits/in.go
+++ b/cl/_testlibgo/mathbits/in.go
@@ -5,7 +5,7 @@ import (
 	"math/bits"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/mathbits.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: %0 = call i64 @"math/bits.Len8"(i8 20)
 	// CHECK: %1 = call i64 @"math/bits.OnesCount"(i64 20)

--- a/cl/_testlibgo/nettextproto/in.go
+++ b/cl/_testlibgo/nettextproto/in.go
@@ -3,7 +3,7 @@ package main
 
 import "net/textproto"
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/nettextproto.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK: %0 = call %"{{.*}}/runtime/internal/runtime.String" @"net/textproto.CanonicalMIMEHeaderKey"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 4 })
 	println(textproto.CanonicalMIMEHeaderKey("host"))

--- a/cl/_testlibgo/os/in.go
+++ b/cl/_testlibgo/os/in.go
@@ -3,7 +3,7 @@ package main
 
 import "os"
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/os.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %0 = call { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @os.Getwd()

--- a/cl/_testlibgo/strings/in.go
+++ b/cl/_testlibgo/strings/in.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testlibgo/strings.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
@@ -28,10 +28,10 @@ func main() {
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %6)
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-	// CHECK-NEXT:   %7 = call i64 @strings.IndexFunc(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 13 }, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testlibgo/strings.main$1", ptr null })
+	// CHECK-NEXT:   %7 = call i64 @strings.IndexFunc(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 13 }, { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null })
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %7)
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-	// CHECK-NEXT:   %8 = call i64 @strings.IndexFunc(%"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 12 }, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testlibgo/strings.main$1", ptr null })
+	// CHECK-NEXT:   %8 = call i64 @strings.IndexFunc(%"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 12 }, { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null })
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %8)
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 	// CHECK-NEXT:   ret void

--- a/cl/_testlto/globaldce_interface_matrix/in.go
+++ b/cl/_testlto/globaldce_interface_matrix/in.go
@@ -5,8 +5,8 @@ package main
 // CHECK-DAG: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.A:func() int")
 // CHECK-DAG: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.B:func(int) int")
 // CHECK-DAG: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.C:func() string")
-// CHECK-DAG: @"_llgo_{{.*}}/cl/_testlto/globaldce_interface_matrix.T1" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility
-// CHECK-DAG: @"*_llgo_{{.*}}/cl/_testlto/globaldce_interface_matrix.T2" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility
+// CHECK-DAG: @_llgo_main.T1 = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility
+// CHECK-DAG: @"*_llgo_main.T2" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility
 // CHECK-DAG: !{i64 {{[0-9]+}}, !"go.method.A:func() int"}
 // CHECK-DAG: !{i64 {{[0-9]+}}, !"go.method.B:func(int) int"}
 // CHECK-DAG: !{i64 {{[0-9]+}}, !"go.method.C:func() string"}

--- a/cl/_testlto/globaldce_interface_matrix/in.go
+++ b/cl/_testlto/globaldce_interface_matrix/in.go
@@ -10,16 +10,16 @@ package main
 // CHECK-DAG: !{i64 {{[0-9]+}}, !"go.method.A:func() int"}
 // CHECK-DAG: !{i64 {{[0-9]+}}, !"go.method.B:func(int) int"}
 // CHECK-DAG: !{i64 {{[0-9]+}}, !"go.method.C:func() string"}
-// SYMBOL-NOT: globaldce_interface_matrix{{.*}}T1{{.*}}Drop
-// SYMBOL-NOT: globaldce_interface_matrix{{.*}}T2{{.*}}Drop
-// SYMBOL-DAG: globaldce_interface_matrix{{.*}}T1{{.*}}A
-// SYMBOL-DAG: globaldce_interface_matrix{{.*}}T1{{.*}}B
-// SYMBOL-DAG: globaldce_interface_matrix{{.*}}T1{{.*}}C
-// SYMBOL-DAG: globaldce_interface_matrix{{.*}}T2{{.*}}A
-// SYMBOL-DAG: globaldce_interface_matrix{{.*}}T2{{.*}}B
-// SYMBOL-DAG: globaldce_interface_matrix{{.*}}T2{{.*}}C
-// SYMBOL-NOT: globaldce_interface_matrix{{.*}}T1{{.*}}Drop
-// SYMBOL-NOT: globaldce_interface_matrix{{.*}}T2{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}T1{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}T2{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}T1{{.*}}A
+// SYMBOL-DAG: main{{.*}}T1{{.*}}B
+// SYMBOL-DAG: main{{.*}}T1{{.*}}C
+// SYMBOL-DAG: main{{.*}}T2{{.*}}A
+// SYMBOL-DAG: main{{.*}}T2{{.*}}B
+// SYMBOL-DAG: main{{.*}}T2{{.*}}C
+// SYMBOL-NOT: main{{.*}}T1{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}T2{{.*}}Drop
 
 type Base interface {
 	A() int

--- a/cl/_testlto/globaldce_interface_slots/in.go
+++ b/cl/_testlto/globaldce_interface_slots/in.go
@@ -5,10 +5,10 @@ package main
 // CHECK-DAG: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.B:func(int) int")
 // CHECK-DAG: !"go.method.A:func() int"
 // CHECK-DAG: !"go.method.B:func(int) int"
-// SYMBOL-NOT: globaldce_interface_slots{{.*}}T{{.*}}Drop
-// SYMBOL-DAG: globaldce_interface_slots{{.*}}T{{.*}}A
-// SYMBOL-DAG: globaldce_interface_slots{{.*}}T{{.*}}B
-// SYMBOL-NOT: globaldce_interface_slots{{.*}}T{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}T{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}T{{.*}}A
+// SYMBOL-DAG: main{{.*}}T{{.*}}B
+// SYMBOL-NOT: main{{.*}}T{{.*}}Drop
 
 type I interface {
 	A() int

--- a/cl/_testlto/globaldce_reflect_method/in.go
+++ b/cl/_testlto/globaldce_reflect_method/in.go
@@ -15,9 +15,9 @@ import "reflect"
 // CHECK-DAG: !"go.method.value.reflect.Keep"
 // CHECK-DAG: !"go.method.type.reflect"
 // CHECK-DAG: !"go.method.type.reflect.Keep"
-// SYMBOL-NOT: globaldce_reflect_method{{.*}}S{{.*}}hidden
-// SYMBOL-DAG: globaldce_reflect_method{{.*}}S{{.*}}Keep
-// SYMBOL-NOT: globaldce_reflect_method{{.*}}S{{.*}}hidden
+// SYMBOL-NOT: main{{.*}}S{{.*}}hidden
+// SYMBOL-DAG: main{{.*}}S{{.*}}Keep
+// SYMBOL-NOT: main{{.*}}S{{.*}}hidden
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/in.go
@@ -6,10 +6,10 @@ import (
 	"reflect"
 )
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin{{.*}}S{{.*}}KeepA
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin{{.*}}S{{.*}}KeepB
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepA
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepB
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_concat/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_concat/in.go
@@ -6,16 +6,16 @@ import (
 	"reflect"
 )
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}KeepValue
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}KeepValueAlt
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}KeepType
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}KeepTypeAlt
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}KeepMultiValue
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}KeepMultiAltValue
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}KeepMultiType
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}KeepMultiAltType
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_concat{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepValue
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepValueAlt
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepType
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepTypeAlt
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepMultiValue
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepMultiAltValue
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepMultiType
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepMultiAltType
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_global/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_global/in.go
@@ -3,12 +3,12 @@ package main
 
 import "reflect"
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_global{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_global{{.*}}S{{.*}}KeepValue
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_global{{.*}}S{{.*}}KeepValueAlt
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_global{{.*}}S{{.*}}KeepType
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_global{{.*}}S{{.*}}KeepTypeAlt
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_global{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepValue
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepValueAlt
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepType
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepTypeAlt
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_global_slice/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_global_slice/in.go
@@ -3,10 +3,10 @@ package main
 
 import "reflect"
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_global_slice{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_global_slice{{.*}}S{{.*}}KeepA
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_global_slice{{.*}}S{{.*}}KeepB
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_global_slice{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepA
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepB
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_loop/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_loop/in.go
@@ -3,10 +3,10 @@ package main
 
 import "reflect"
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_loop{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_loop{{.*}}S{{.*}}KeepLoopA
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_loop{{.*}}S{{.*}}KeepLoopB
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_loop{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepLoopA
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepLoopB
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_param/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_param/in.go
@@ -3,12 +3,12 @@ package main
 
 import "reflect"
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}KeepParamValueA
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}KeepParamValueB
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}KeepParamTypeA
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}KeepParamTypeB
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepParamValueA
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepParamValueB
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepParamTypeA
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepParamTypeB
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_range_literal/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_range_literal/in.go
@@ -3,11 +3,11 @@ package main
 
 import "reflect"
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_range_literal{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_range_literal{{.*}}S{{.*}}Query
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_range_literal{{.*}}S{{.*}}Mutation
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_range_literal{{.*}}S{{.*}}Subscription
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_range_literal{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}Query
+// SYMBOL-DAG: main{{.*}}S{{.*}}Mutation
+// SYMBOL-DAG: main{{.*}}S{{.*}}Subscription
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 const (
 	Query        = "Query"

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_slice/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_slice/in.go
@@ -3,10 +3,10 @@ package main
 
 import "reflect"
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_slice{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_slice{{.*}}S{{.*}}KeepSliceValue
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_slice{{.*}}S{{.*}}KeepSliceType
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_slice{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepSliceValue
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepSliceType
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_string_abi/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_string_abi/in.go
@@ -5,12 +5,12 @@ import (
 	"reflect"
 )
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Direct
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Concat
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Slice
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Forward
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}Known{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}Known{{.*}}Direct
+// SYMBOL-DAG: main{{.*}}Known{{.*}}Concat
+// SYMBOL-DAG: main{{.*}}Known{{.*}}Slice
+// SYMBOL-DAG: main{{.*}}Known{{.*}}Forward
+// SYMBOL-NOT: main{{.*}}Known{{.*}}Drop
 
 type Known struct{}
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_switch/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_switch/in.go
@@ -6,11 +6,11 @@ import (
 	"reflect"
 )
 
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}KeepA
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}KeepB
-// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}KeepC
-// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepA
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepB
+// SYMBOL-DAG: main{{.*}}S{{.*}}KeepC
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_type_method/in.go
+++ b/cl/_testlto/globaldce_reflect_type_method/in.go
@@ -3,9 +3,9 @@ package main
 
 import "reflect"
 
-// CHECK-DAG: @"_llgo_{{.*}}globaldce_reflect_type_method.S" = weak_odr constant {{.*}}, !type ![[SIG:[0-9]+]], !type ![[VANY:[0-9]+]], !type ![[VKEEP:[0-9]+]], !type ![[TANY:[0-9]+]], !type ![[TKEEP:[0-9]+]], !vcall_visibility !{{[0-9]+}}
-// CHECK-DAG: @"*_llgo_{{.*}}globaldce_reflect_type_method.S" = weak_odr constant {{.*}}, !type !{{[0-9]+}}, !type !{{[0-9]+}}, !type !{{[0-9]+}}, !type !{{[0-9]+}}, !type !{{[0-9]+}}, !vcall_visibility !{{[0-9]+}}
-// CHECK-LABEL: define void @"github.com/goplus/llgo/cl/_testlto/globaldce_reflect_type_method.main"
+// CHECK-DAG: @_llgo_main.S = weak_odr constant {{.*}}, !type ![[SIG:[0-9]+]], !type ![[VANY:[0-9]+]], !type ![[VKEEP:[0-9]+]], !type ![[TANY:[0-9]+]], !type ![[TKEEP:[0-9]+]], !vcall_visibility !{{[0-9]+}}
+// CHECK-DAG: @"*_llgo_main.S" = weak_odr constant {{.*}}, !type !{{[0-9]+}}, !type !{{[0-9]+}}, !type !{{[0-9]+}}, !type !{{[0-9]+}}, !type !{{[0-9]+}}, !vcall_visibility !{{[0-9]+}}
+// CHECK-LABEL: define void @main.main
 // CHECK: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.Method:func(int) reflect.Method")
 // CHECK-NOT: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.value.reflect")
 // CHECK: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.type.reflect")

--- a/cl/_testlto/globaldce_reflect_type_method_by_name/in.go
+++ b/cl/_testlto/globaldce_reflect_type_method_by_name/in.go
@@ -15,9 +15,9 @@ import "reflect"
 // CHECK-DAG: !"go.method.Drop:func() string"
 // CHECK-DAG: !"go.method.type.reflect.Keep"
 // CHECK-DAG: !"go.method.type.reflect.Drop"
-// SYMBOL-NOT: globaldce_reflect_type_method_by_name{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_type_method_by_name{{.*}}S{{.*}}Keep
-// SYMBOL-NOT: globaldce_reflect_type_method_by_name{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}Keep
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_reflect_type_method_by_name/in.go
+++ b/cl/_testlto/globaldce_reflect_type_method_by_name/in.go
@@ -3,9 +3,9 @@ package main
 
 import "reflect"
 
-// CHECK-DAG: @"_llgo_{{.*}}globaldce_reflect_type_method_by_name.S" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility !{{[0-9]+}}
-// CHECK-DAG: @"*_llgo_{{.*}}globaldce_reflect_type_method_by_name.S" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility !{{[0-9]+}}
-// CHECK-LABEL: define void @"github.com/goplus/llgo/cl/_testlto/globaldce_reflect_type_method_by_name.main"
+// CHECK-DAG: @_llgo_main.S = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility !{{[0-9]+}}
+// CHECK-DAG: @"*_llgo_main.S" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility !{{[0-9]+}}
+// CHECK-LABEL: define void @main.main
 // CHECK-NOT: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.value.reflect")
 // CHECK-NOT: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.type.reflect")
 // CHECK: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.type.reflect.Keep")

--- a/cl/_testlto/globaldce_reflect_value_method/in.go
+++ b/cl/_testlto/globaldce_reflect_value_method/in.go
@@ -3,9 +3,9 @@ package main
 
 import "reflect"
 
-// CHECK-DAG: @"_llgo_{{.*}}globaldce_reflect_value_method.S" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility !{{[0-9]+}}
-// CHECK-DAG: @"*_llgo_{{.*}}globaldce_reflect_value_method.S" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility !{{[0-9]+}}
-// CHECK-LABEL: define void @"github.com/goplus/llgo/cl/_testlto/globaldce_reflect_value_method.main"
+// CHECK-DAG: @_llgo_main.S = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility !{{[0-9]+}}
+// CHECK-DAG: @"*_llgo_main.S" = weak_odr constant {{.*}}, !type !{{[0-9]+}}{{.*}}, !vcall_visibility !{{[0-9]+}}
+// CHECK-LABEL: define void @main.main
 // CHECK-NOT: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.type.reflect")
 // CHECK-NOT: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.value.reflect")
 // CHECK: call { ptr, i1 } @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"go.method.value.reflect.Keep")

--- a/cl/_testlto/globaldce_reflect_value_method/in.go
+++ b/cl/_testlto/globaldce_reflect_value_method/in.go
@@ -15,9 +15,9 @@ import "reflect"
 // CHECK-DAG: !"go.method.Drop:func() string"
 // CHECK-DAG: !"go.method.value.reflect.Keep"
 // CHECK-DAG: !"go.method.value.reflect.Drop"
-// SYMBOL-NOT: globaldce_reflect_value_method{{.*}}S{{.*}}Drop
-// SYMBOL-DAG: globaldce_reflect_value_method{{.*}}S{{.*}}Keep
-// SYMBOL-NOT: globaldce_reflect_value_method{{.*}}S{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: main{{.*}}S{{.*}}Keep
+// SYMBOL-NOT: main{{.*}}S{{.*}}Drop
 
 type S struct{}
 

--- a/cl/_testlto/globaldce_typeid_dce/in.go
+++ b/cl/_testlto/globaldce_typeid_dce/in.go
@@ -5,11 +5,11 @@ package main
 // CHECK-DAG: !"go.method.Keep:func() int"
 // CHECK-DAG: !"go.method.value.reflect"
 // CHECK-DAG: !"go.method.type.reflect"
-// SYMBOL-NOT: globaldce_typeid_dce{{.*}}Worker{{.*}}Drop
-// SYMBOL-NOT: globaldce_typeid_dce{{.*}}Worker{{.*}}DropWithArg
-// SYMBOL-DAG: globaldce_typeid_dce{{.*}}Worker{{.*}}Keep
-// SYMBOL-NOT: globaldce_typeid_dce{{.*}}Worker{{.*}}Drop
-// SYMBOL-NOT: globaldce_typeid_dce{{.*}}Worker{{.*}}DropWithArg
+// SYMBOL-NOT: main{{.*}}Worker{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}Worker{{.*}}DropWithArg
+// SYMBOL-DAG: main{{.*}}Worker{{.*}}Keep
+// SYMBOL-NOT: main{{.*}}Worker{{.*}}Drop
+// SYMBOL-NOT: main{{.*}}Worker{{.*}}DropWithArg
 
 type Keeper interface {
 	Keep() int

--- a/cl/_testlto/globaldce_unexported_method_identity/in.go
+++ b/cl/_testlto/globaldce_unexported_method_identity/in.go
@@ -10,10 +10,10 @@ import (
 // CHECK-DAG: !"go.method.github.com/goplus/llgo/cl/_testlto/globaldce_unexported_method_identity/other.hidden:func() int"
 // CHECK-DAG: !"go.method.github.com/goplus/llgo/cl/_testlto/globaldce_unexported_method_identity.hidden:func() int"
 // SYMBOL-NOT: globaldce_unexported_method_identity/other{{.*}}Other{{.*}}hidden
-// SYMBOL-NOT: globaldce_unexported_method_identity{{.*}}Local{{.*}}hidden
+// SYMBOL-NOT: main{{.*}}Local{{.*}}hidden
 // SYMBOL-DAG: globaldce_unexported_method_identity/base{{.*}}Exported{{.*}}hidden
 // SYMBOL-NOT: globaldce_unexported_method_identity/other{{.*}}Other{{.*}}hidden
-// SYMBOL-NOT: globaldce_unexported_method_identity{{.*}}Local{{.*}}hidden
+// SYMBOL-NOT: main{{.*}}Local{{.*}}hidden
 
 type Combined struct {
 	base.Exported

--- a/cl/_testmeta/ifaceuse_basic/meta-expect.txt
+++ b/cl/_testmeta/ifaceuse_basic/meta-expect.txt
@@ -1,26 +1,26 @@
 [TypeChildren]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+*_llgo_main.T:
+    _llgo_main.T
 
 [OrdinaryEdges]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T:
+*_llgo_main.T:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+    _llgo_main.T
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
     github.com/goplus/llgo/runtime/internal/runtime.memequal0
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
     github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-_llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+_llgo_main.T:
+    *_llgo_main.T
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
-github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.init:
-    github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.init$guard
-github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
-    github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.sink
+main.init:
+    main.init$guard
+main.main:
+    _llgo_main.T
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    main.sink
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+main.main:
+    _llgo_main.T
 

--- a/cl/_testmeta/interface_anyonmous/meta-expect.txt
+++ b/cl/_testmeta/interface_anyonmous/meta-expect.txt
@@ -1,81 +1,81 @@
 [TypeChildren]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
 *_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
     _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo
+*_llgo_main.T:
+    _llgo_main.T
 
 [OrdinaryEdges]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
-    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
 *_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M:
-    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N:
-    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.M:
-    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.M
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.N:
-    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.N
+*_llgo_main.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_main.T
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal:
     github.com/goplus/llgo/runtime/internal/runtime.interequal
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
     github.com/goplus/llgo/runtime/internal/runtime.memequal0
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
     github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+__llgo_stub.main.(*T).M:
+    main.(*T).M
+__llgo_stub.main.(*T).N:
+    main.(*T).N
+__llgo_stub.main.T.M:
+    main.T.M
+__llgo_stub.main.T.N:
+    main.T.N
 _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
-    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
 _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
     *_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
     _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo$imethods
 _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo$imethods:
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M:
-    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.M
+_llgo_main.T:
+    *_llgo_main.T
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+main.(*T).M:
     github.com/goplus/llgo/runtime/internal/runtime.AssertNilDeref
     github.com/goplus/llgo/runtime/internal/runtime.PanicWrapNilPointer
-github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N:
-    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.N
+    main.T.M
+main.(*T).N:
     github.com/goplus/llgo/runtime/internal/runtime.AssertNilDeref
     github.com/goplus/llgo/runtime/internal/runtime.PanicWrapNilPointer
-github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.init:
-    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.init$guard
-github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
+    main.T.N
+main.init:
+    main.init$guard
+main.main:
     _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo
-    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.use
+    _llgo_main.T
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
     github.com/goplus/llgo/runtime/internal/runtime.NewItab
-github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.use:
+    main.use
+main.use:
     github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
+main.main:
+    _llgo_main.T
 
 [UseIfaceMethod]
-github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.use:
+main.use:
     _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
     _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
 
 [MethodInfo]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
-    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M
-    1 N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N
-_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
-    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.M
-    1 N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.N
+*_llgo_main.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).M __llgo_stub.main.(*T).M
+    1 N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).N __llgo_stub.main.(*T).N
+_llgo_main.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).M __llgo_stub.main.T.M
+    1 N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).N __llgo_stub.main.T.N
 
 [InterfaceInfo]
 _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:

--- a/cl/_testmeta/interface_exported_var/meta-expect.txt
+++ b/cl/_testmeta/interface_exported_var/meta-expect.txt
@@ -289,10 +289,10 @@ _llgo_uint64:
 _llgo_uint8:
     *_llgo_uint8
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8
-github.com/goplus/llgo/cl/_testmeta/interface_exported_var.init:
+main.init:
     encoding/binary.init
-    github.com/goplus/llgo/cl/_testmeta/interface_exported_var.init$guard
-github.com/goplus/llgo/cl/_testmeta/interface_exported_var.main:
+    main.init$guard
+main.main:
     _llgo_encoding/binary.littleEndian
     _llgo_iface$J1wM-rGcIPemx5jloXBmH7pUzUCSqpgNkOdb0QIFTxw
     encoding/binary.LittleEndian
@@ -303,11 +303,11 @@ github.com/goplus/llgo/cl/_testmeta/interface_exported_var.main:
     github.com/goplus/llgo/runtime/internal/runtime.Typedmemmove
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/interface_exported_var.main:
+main.main:
     _llgo_encoding/binary.littleEndian
 
 [UseIfaceMethod]
-github.com/goplus/llgo/cl/_testmeta/interface_exported_var.main:
+main.main:
     _llgo_iface$J1wM-rGcIPemx5jloXBmH7pUzUCSqpgNkOdb0QIFTxw Uint16 _llgo_func$hV5ojfmZDe6MffI0ylemgDF5GZlZiYaJbQvka2A0Gus
 
 [MethodInfo]

--- a/cl/_testmeta/interface_generic/meta-expect.txt
+++ b/cl/_testmeta/interface_generic/meta-expect.txt
@@ -1,47 +1,43 @@
 [TypeChildren]
 *_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
     _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]
 *_llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8:
     _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8
 *_llgo_int:
     _llgo_int
+*_llgo_main.Box[int]:
+    _llgo_main.Box[int]
 _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
     _llgo_int
-_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]:
+_llgo_main.Box[int]:
     _llgo_int
 
 [OrdinaryEdges]
 *_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]:
-    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]
 *_llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8
 *_llgo_int:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_int
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_generic.(*Box[int]).Value:
-    github.com/goplus/llgo/cl/_testmeta/interface_generic.(*Box[int]).Value
+*_llgo_main.Box[int]:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_main.Box[int]
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal:
     github.com/goplus/llgo/runtime/internal/runtime.interequal
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64:
     github.com/goplus/llgo/runtime/internal/runtime.memequal64
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
     github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+__llgo_stub.main.(*Box[int]).Value:
+    main.(*Box[int]).Value
 _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
     *_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
     _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out
 _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out:
     _llgo_int
-_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]
-    github.com/goplus/llgo/cl/_testmeta/interface_generic.struct$lOhriNu2BrWBR2Mh8k-KggMYlAw0Wx-2ftE2_gNyubg$fields
-    github.com/goplus/llgo/runtime/internal/runtime.structequal
 _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8:
     *_llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
@@ -51,30 +47,34 @@ _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8$imethods:
 _llgo_int:
     *_llgo_int
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64
-github.com/goplus/llgo/cl/_testmeta/interface_generic.init:
-    github.com/goplus/llgo/cl/_testmeta/interface_generic.init$guard
-github.com/goplus/llgo/cl/_testmeta/interface_generic.main:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]
-    _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8
-    github.com/goplus/llgo/cl/_testmeta/interface_generic.useInt
-    github.com/goplus/llgo/runtime/internal/runtime.AllocZ
-    github.com/goplus/llgo/runtime/internal/runtime.NewItab
+_llgo_main.Box[int]:
+    *_llgo_main.Box[int]
+    github.com/goplus/llgo/cl/_testmeta/interface_generic.struct$lOhriNu2BrWBR2Mh8k-KggMYlAw0Wx-2ftE2_gNyubg$fields
+    github.com/goplus/llgo/runtime/internal/runtime.structequal
 github.com/goplus/llgo/cl/_testmeta/interface_generic.struct$lOhriNu2BrWBR2Mh8k-KggMYlAw0Wx-2ftE2_gNyubg$fields:
     _llgo_int
-github.com/goplus/llgo/cl/_testmeta/interface_generic.useInt:
+main.init:
+    main.init$guard
+main.main:
+    *_llgo_main.Box[int]
+    _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8
+    github.com/goplus/llgo/runtime/internal/runtime.AllocZ
+    github.com/goplus/llgo/runtime/internal/runtime.NewItab
+    main.useInt
+main.useInt:
     github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/interface_generic.main:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]
+main.main:
+    *_llgo_main.Box[int]
 
 [UseIfaceMethod]
-github.com/goplus/llgo/cl/_testmeta/interface_generic.useInt:
+main.useInt:
     _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8 Value _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
 
 [MethodInfo]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic.Box[int]:
-    0 Value _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA github.com/goplus/llgo/cl/_testmeta/interface_generic.(*Box[int]).Value __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_generic.(*Box[int]).Value
+*_llgo_main.Box[int]:
+    0 Value _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA main.(*Box[int]).Value __llgo_stub.main.(*Box[int]).Value
 
 [InterfaceInfo]
 _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8:

--- a/cl/_testmeta/interface_generic_crosspkg/meta-expect.txt
+++ b/cl/_testmeta/interface_generic_crosspkg/meta-expect.txt
@@ -90,22 +90,6 @@ _llgo_int:
 _llgo_string:
     *_llgo_string
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal
-github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg.init:
-    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg.init$guard
-    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/api.init
-    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.init
-github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg.main:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.Box[int]
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.Box[string]
-    _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8
-    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg.sink
-    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/api.UseInt
-    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.NewIntBox
-    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.NewStringBox
-    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.UseStringBox
-    github.com/goplus/llgo/runtime/internal/runtime.NewItab
-    github.com/goplus/llgo/runtime/internal/runtime.PrintByte
-    github.com/goplus/llgo/runtime/internal/runtime.PrintInt
 github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.(*Box[int]).Drop:
     _llgo_string
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
@@ -118,15 +102,31 @@ github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.struct$XNpH
     _llgo_string
 github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.struct$lOhriNu2BrWBR2Mh8k-KggMYlAw0Wx-2ftE2_gNyubg$fields:
     _llgo_int
-
-[UseIface]
-github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg.main:
+main.init:
+    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/api.init
+    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.init
+    main.init$guard
+main.main:
     *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.Box[int]
     *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.Box[string]
+    _llgo_iface$Jvxc0PCI_drlfK7S5npMGdZkQLeRkQ_x2e2CifPE6w8
+    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/api.UseInt
+    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.NewIntBox
+    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.NewStringBox
+    github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.UseStringBox
+    github.com/goplus/llgo/runtime/internal/runtime.NewItab
+    github.com/goplus/llgo/runtime/internal/runtime.PrintByte
+    github.com/goplus/llgo/runtime/internal/runtime.PrintInt
+    main.sink
+
+[UseIface]
 github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.(*Box[int]).Drop:
     _llgo_string
 github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.(*Box[string]).Drop:
     _llgo_string
+main.main:
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.Box[int]
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.Box[string]
 
 [MethodInfo]
 *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_generic_crosspkg/model.Box[int]:

--- a/cl/_testmeta/interface_imported/meta-expect.txt
+++ b/cl/_testmeta/interface_imported/meta-expect.txt
@@ -127,24 +127,24 @@ _llgo_string:
 _llgo_uint8:
     *_llgo_uint8
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8
-github.com/goplus/llgo/cl/_testmeta/interface_imported.init:
-    github.com/goplus/llgo/cl/_testmeta/interface_imported.init$guard
+main.init:
     github.com/goplus/llgo/cl/_testmeta/interface_imported/api.init
-github.com/goplus/llgo/cl/_testmeta/interface_imported.main:
+    main.init$guard
+main.main:
     _llgo_github.com/goplus/llgo/cl/_testmeta/interface_imported/api.Source
     _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw
-    github.com/goplus/llgo/cl/_testmeta/interface_imported.use
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
     github.com/goplus/llgo/runtime/internal/runtime.NewItab
-github.com/goplus/llgo/cl/_testmeta/interface_imported.use:
+    main.use
+main.use:
     github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/interface_imported.main:
+main.main:
     _llgo_github.com/goplus/llgo/cl/_testmeta/interface_imported/api.Source
 
 [UseIfaceMethod]
-github.com/goplus/llgo/cl/_testmeta/interface_imported.use:
+main.use:
     _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw Read _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
 
 [MethodInfo]

--- a/cl/_testmeta/interface_named/meta-expect.txt
+++ b/cl/_testmeta/interface_named/meta-expect.txt
@@ -1,70 +1,70 @@
 [TypeChildren]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
 *_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88:
     _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88
+*_llgo_main.T:
+    _llgo_main.T
 
 [OrdinaryEdges]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
-    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
 *_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M:
-    github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_named.T.M:
-    github.com/goplus/llgo/cl/_testmeta/interface_named.T.M
+*_llgo_main.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_main.T
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal:
     github.com/goplus/llgo/runtime/internal/runtime.interequal
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
     github.com/goplus/llgo/runtime/internal/runtime.memequal0
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
     github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+__llgo_stub.main.(*T).M:
+    main.(*T).M
+__llgo_stub.main.T.M:
+    main.T.M
 _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
-    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
 _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88:
     *_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
     _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88$imethods
 _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88$imethods:
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M:
-    github.com/goplus/llgo/cl/_testmeta/interface_named.T.M
+_llgo_main.T:
+    *_llgo_main.T
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+main.(*T).M:
     github.com/goplus/llgo/runtime/internal/runtime.AssertNilDeref
     github.com/goplus/llgo/runtime/internal/runtime.PanicWrapNilPointer
-github.com/goplus/llgo/cl/_testmeta/interface_named.init:
-    github.com/goplus/llgo/cl/_testmeta/interface_named.init$guard
-github.com/goplus/llgo/cl/_testmeta/interface_named.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
+    main.T.M
+main.init:
+    main.init$guard
+main.main:
     _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88
-    github.com/goplus/llgo/cl/_testmeta/interface_named.use
+    _llgo_main.T
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
     github.com/goplus/llgo/runtime/internal/runtime.NewItab
-github.com/goplus/llgo/cl/_testmeta/interface_named.use:
+    main.use
+main.use:
     github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/interface_named.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
+main.main:
+    _llgo_main.T
 
 [UseIfaceMethod]
-github.com/goplus/llgo/cl/_testmeta/interface_named.use:
+main.use:
     _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
 
 [MethodInfo]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
-    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M
-_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
-    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_named.T.M
+*_llgo_main.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).M __llgo_stub.main.(*T).M
+_llgo_main.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).M __llgo_stub.main.T.M
 
 [InterfaceInfo]
 _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88:

--- a/cl/_testmeta/interface_unexported/meta-expect.txt
+++ b/cl/_testmeta/interface_unexported/meta-expect.txt
@@ -1,8 +1,8 @@
 [TypeChildren]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+*_llgo_main.T:
+    _llgo_main.T
 *github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo:
     github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo
 
@@ -10,63 +10,63 @@
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
+*_llgo_main.T:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+    _llgo_main.T
 *github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m:
-    github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_unexported.T.m:
-    github.com/goplus/llgo/cl/_testmeta/interface_unexported.T.m
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal:
     github.com/goplus/llgo/runtime/internal/runtime.interequal
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
     github.com/goplus/llgo/runtime/internal/runtime.memequal0
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
     github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+__llgo_stub.main.(*T).m:
+    main.(*T).m
+__llgo_stub.main.T.m:
+    main.T.m
 _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+_llgo_main.T:
+    *_llgo_main.T
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
-github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m:
-    github.com/goplus/llgo/cl/_testmeta/interface_unexported.T.m
-    github.com/goplus/llgo/runtime/internal/runtime.AssertNilDeref
-    github.com/goplus/llgo/runtime/internal/runtime.PanicWrapNilPointer
 github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo:
     *github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
     github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo$imethods
 github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo$imethods:
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-github.com/goplus/llgo/cl/_testmeta/interface_unexported.init:
-    github.com/goplus/llgo/cl/_testmeta/interface_unexported.init$guard
-github.com/goplus/llgo/cl/_testmeta/interface_unexported.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+main.(*T).m:
+    github.com/goplus/llgo/runtime/internal/runtime.AssertNilDeref
+    github.com/goplus/llgo/runtime/internal/runtime.PanicWrapNilPointer
+    main.T.m
+main.init:
+    main.init$guard
+main.main:
+    _llgo_main.T
     github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo
-    github.com/goplus/llgo/cl/_testmeta/interface_unexported.use
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
     github.com/goplus/llgo/runtime/internal/runtime.NewItab
-github.com/goplus/llgo/cl/_testmeta/interface_unexported.use:
+    main.use
+main.use:
     github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/interface_unexported.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+main.main:
+    _llgo_main.T
 
 [UseIfaceMethod]
-github.com/goplus/llgo/cl/_testmeta/interface_unexported.use:
-    github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo github.com/goplus/llgo/cl/_testmeta/interface_unexported.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+main.use:
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo main.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
 
 [MethodInfo]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
-    0 github.com/goplus/llgo/cl/_testmeta/interface_unexported.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m
-_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
-    0 github.com/goplus/llgo/cl/_testmeta/interface_unexported.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m __llgo_stub.github.com/goplus/llgo/cl/_testmeta/interface_unexported.T.m
+*_llgo_main.T:
+    0 main.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).m __llgo_stub.main.(*T).m
+_llgo_main.T:
+    0 main.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).m __llgo_stub.main.T.m
 
 [InterfaceInfo]
 github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo:
-    github.com/goplus/llgo/cl/_testmeta/interface_unexported.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+    main.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
 

--- a/cl/_testmeta/methodinfo_imported/meta-expect.txt
+++ b/cl/_testmeta/methodinfo_imported/meta-expect.txt
@@ -510,11 +510,11 @@ bytes.struct$8M6lRFZ7Fk2XCr2laNI9Y7uQtk2A8VDBrezMuq2Fkuo$fields:
     []_llgo_uint8
     _llgo_bytes.readOp
     _llgo_int
-github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.init:
+main.init:
     bytes.init
-    github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.init$guard
     io.init
-github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.main:
+    main.init$guard
+main.main:
     *_llgo_bytes.Buffer
     _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw
     bytes.NewBuffer
@@ -522,11 +522,11 @@ github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.main:
     github.com/goplus/llgo/runtime/internal/runtime.NewItab
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.main:
+main.main:
     *_llgo_bytes.Buffer
 
 [UseIfaceMethod]
-github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.main:
+main.main:
     _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw Read _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
 
 [MethodInfo]

--- a/cl/_testmeta/reflect_dynamic/meta-expect.txt
+++ b/cl/_testmeta/reflect_dynamic/meta-expect.txt
@@ -1,54 +1,54 @@
 [TypeChildren]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+*_llgo_main.T:
+    _llgo_main.T
 
 [OrdinaryEdges]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
+*_llgo_main.T:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M:
-    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T.M:
-    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T.M
+    _llgo_main.T
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
     github.com/goplus/llgo/runtime/internal/runtime.memequal0
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
     github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+__llgo_stub.main.(*T).M:
+    main.(*T).M
+__llgo_stub.main.T.M:
+    main.T.M
 _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+_llgo_main.T:
+    *_llgo_main.T
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
-github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M:
-    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T.M
+main.(*T).M:
     github.com/goplus/llgo/runtime/internal/runtime.AssertNilDeref
     github.com/goplus/llgo/runtime/internal/runtime.PanicWrapNilPointer
-github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.init:
-    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.init$guard
+    main.T.M
+main.init:
+    main.init$guard
     reflect.init
-github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.main:
-    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.use
-github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.use:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+main.main:
+    main.use
+main.use:
+    _llgo_main.T
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
     reflect.Value.MethodByName
     reflect.ValueOf
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.use:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+main.use:
+    _llgo_main.T
 
 [MethodInfo]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
-    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M __llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M
-_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
-    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M __llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T.M
+*_llgo_main.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).M __llgo_stub.main.(*T).M
+_llgo_main.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).M __llgo_stub.main.T.M
 
 [Reflect]
-    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.use
+    main.use
 

--- a/cl/_testmeta/reflect_named/meta-expect.txt
+++ b/cl/_testmeta/reflect_named/meta-expect.txt
@@ -1,72 +1,72 @@
 [TypeChildren]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+*_llgo_main.T:
+    _llgo_main.T
 
 [OrdinaryEdges]
 *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
+*_llgo_main.T:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M:
-    github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m:
-    github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_named.T.M:
-    github.com/goplus/llgo/cl/_testmeta/reflect_named.T.M
-__llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_named.T.m:
-    github.com/goplus/llgo/cl/_testmeta/reflect_named.T.m
+    _llgo_main.T
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
     github.com/goplus/llgo/runtime/internal/runtime.memequal0
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
     github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+__llgo_stub.main.(*T).M:
+    main.(*T).M
+__llgo_stub.main.(*T).m:
+    main.(*T).m
+__llgo_stub.main.T.M:
+    main.T.M
+__llgo_stub.main.T.m:
+    main.T.m
 _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
     *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
-_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+_llgo_main.T:
+    *_llgo_main.T
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
-github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M:
-    github.com/goplus/llgo/cl/_testmeta/reflect_named.T.M
+main.(*T).M:
     github.com/goplus/llgo/runtime/internal/runtime.AssertNilDeref
     github.com/goplus/llgo/runtime/internal/runtime.PanicWrapNilPointer
-github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m:
-    github.com/goplus/llgo/cl/_testmeta/reflect_named.T.m
+    main.T.M
+main.(*T).m:
     github.com/goplus/llgo/runtime/internal/runtime.AssertNilDeref
     github.com/goplus/llgo/runtime/internal/runtime.PanicWrapNilPointer
-github.com/goplus/llgo/cl/_testmeta/reflect_named.init:
-    github.com/goplus/llgo/cl/_testmeta/reflect_named.init$guard
+    main.T.m
+main.init:
+    main.init$guard
     reflect.init
-github.com/goplus/llgo/cl/_testmeta/reflect_named.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+main.main:
+    _llgo_main.T
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
     github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
     reflect.TypeOf
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/reflect_named.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
-    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+main.main:
+    _llgo_main.T
+    _llgo_main.T
 
 [UseIfaceMethod]
-github.com/goplus/llgo/cl/_testmeta/reflect_named.main:
+main.main:
     github.com/goplus/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
     github.com/goplus/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
 
 [UseNamedMethod]
-github.com/goplus/llgo/cl/_testmeta/reflect_named.main:
+main.main:
     M
     m
 
 [MethodInfo]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
-    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M __llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M
-    1 github.com/goplus/llgo/cl/_testmeta/reflect_named.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m __llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m
-_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
-    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M __llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_named.T.M
-    1 github.com/goplus/llgo/cl/_testmeta/reflect_named.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m __llgo_stub.github.com/goplus/llgo/cl/_testmeta/reflect_named.T.m
+*_llgo_main.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).M __llgo_stub.main.(*T).M
+    1 main.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).m __llgo_stub.main.(*T).m
+_llgo_main.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).M __llgo_stub.main.T.M
+    1 main.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac main.(*T).m __llgo_stub.main.T.m
 
 [InterfaceInfo]
 github.com/goplus/llgo/runtime/internal/lib/reflect.iface$mD8cc0P9iPHqG1cgYNbFpshv9b41oJ45HmjD5KeBlWw:

--- a/cl/_testmeta/typechildren_basic/meta-expect.txt
+++ b/cl/_testmeta/typechildren_basic/meta-expect.txt
@@ -1,28 +1,28 @@
 [TypeChildren]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
-*_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
 *_llgo_int:
     _llgo_int
+*_llgo_main.Inner:
+    _llgo_main.Inner
+*_llgo_main.Outer:
+    _llgo_main.Outer
 *_llgo_string:
     _llgo_string
-_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner:
+_llgo_main.Inner:
     _llgo_string
-_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
+_llgo_main.Outer:
     _llgo_int
+    _llgo_main.Inner
 
 [OrdinaryEdges]
-*_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner:
-    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
-*_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer:
-    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
-    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
 *_llgo_int:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_int
+*_llgo_main.Inner:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_main.Inner
+*_llgo_main.Outer:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_main.Outer
 *_llgo_string:
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
     _llgo_string
@@ -32,33 +32,33 @@ __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
     github.com/goplus/llgo/runtime/internal/runtime.memequalptr
 __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal:
     github.com/goplus/llgo/runtime/internal/runtime.strequal
-_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
-    _llgo_struct$MTAKiWNMPODH0G9-y5PI3BUGLd6hRciSbX1QTpCDOZg$fields
-    github.com/goplus/llgo/runtime/internal/runtime.structequal
-_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer:
-    *_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
-    _llgo_struct$VaHvQdd7oPMFznC6BSA9M_OXdmuO77w_Ys1GnWZpjRM$fields
-    github.com/goplus/llgo/runtime/internal/runtime.structequal
 _llgo_int:
     *_llgo_int
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64
+_llgo_main.Inner:
+    *_llgo_main.Inner
+    _llgo_struct$MTAKiWNMPODH0G9-y5PI3BUGLd6hRciSbX1QTpCDOZg$fields
+    github.com/goplus/llgo/runtime/internal/runtime.structequal
+_llgo_main.Outer:
+    *_llgo_main.Outer
+    _llgo_struct$Z-8Mj1VAYg5xS_jUvJKfmUcA_2fP_OEHpanbgA_46rE$fields
+    github.com/goplus/llgo/runtime/internal/runtime.structequal
 _llgo_string:
     *_llgo_string
     __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal
 _llgo_struct$MTAKiWNMPODH0G9-y5PI3BUGLd6hRciSbX1QTpCDOZg$fields:
     _llgo_string
-_llgo_struct$VaHvQdd7oPMFznC6BSA9M_OXdmuO77w_Ys1GnWZpjRM$fields:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
+_llgo_struct$Z-8Mj1VAYg5xS_jUvJKfmUcA_2fP_OEHpanbgA_46rE$fields:
     _llgo_int
-github.com/goplus/llgo/cl/_testmeta/typechildren_basic.init:
-    github.com/goplus/llgo/cl/_testmeta/typechildren_basic.init$guard
-github.com/goplus/llgo/cl/_testmeta/typechildren_basic.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
-    github.com/goplus/llgo/cl/_testmeta/typechildren_basic.use
+    _llgo_main.Inner
+main.init:
+    main.init$guard
+main.main:
+    _llgo_main.Outer
     github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    main.use
 
 [UseIface]
-github.com/goplus/llgo/cl/_testmeta/typechildren_basic.main:
-    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
+main.main:
+    _llgo_main.Outer
 

--- a/cl/_testpy/callpy/in.go
+++ b/cl/_testpy/callpy/in.go
@@ -20,13 +20,13 @@ func main() {
 	c.Printf(c.Str("cwd ok = %d\n"), int(wd.IsTrue()))
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/callpy.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testpy/callpy.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testpy/callpy.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @"github.com/goplus/lib/py/math.init"()
 // CHECK-NEXT:   call void @"github.com/goplus/lib/py/os.init"()
 // CHECK-NEXT:   %1 = load ptr, ptr @__llgo_py.math, align 8
@@ -39,7 +39,7 @@ func main() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/callpy.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @PyFloat_FromDouble(double 2.000000e+00)
 // CHECK-NEXT:   %1 = load ptr, ptr @__llgo_py.math.sqrt, align 8

--- a/cl/_testpy/gcd/in.go
+++ b/cl/_testpy/gcd/in.go
@@ -7,7 +7,7 @@ import (
 	"github.com/goplus/lib/py/math"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/gcd.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @PyLong_FromLong(i64 60)
 // CHECK-NEXT:   %1 = call ptr @PyLong_FromLong(i64 20)

--- a/cl/_testpy/list/in.go
+++ b/cl/_testpy/list/in.go
@@ -29,13 +29,13 @@ func main() {
 	c.Printf(c.Str("pi = %.15g\n"), y.ListItem(2).Float64())
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/list.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testpy/list.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testpy/list.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @"github.com/goplus/lib/py/math.init"()
 // CHECK-NEXT:   call void @"github.com/goplus/lib/py/std.init"()
 // CHECK-NEXT:   %1 = load ptr, ptr @__llgo_py.builtins, align 8
@@ -46,7 +46,7 @@ func main() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/list.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 100, ptr %0, align 8

--- a/cl/_testpy/matrix/in.go
+++ b/cl/_testpy/matrix/in.go
@@ -7,7 +7,7 @@ import (
 	"github.com/goplus/lib/py/numpy"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/matrix.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @PyList_New(i64 3)
 // CHECK-NEXT:   %1 = call ptr @PyFloat_FromDouble(double 1.000000e+00)

--- a/cl/_testpy/max/in.go
+++ b/cl/_testpy/max/in.go
@@ -6,7 +6,7 @@ import (
 	"github.com/goplus/lib/py/std"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/max.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @PyFloat_FromDouble(double 3.000000e+00)
 // CHECK-NEXT:   %1 = call ptr @PyFloat_FromDouble(double 9.000000e+00)

--- a/cl/_testpy/pi/in.go
+++ b/cl/_testpy/pi/in.go
@@ -6,7 +6,7 @@ import (
 	"github.com/goplus/lib/py/math"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/pi.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = load ptr, ptr @__llgo_py.math, align 8
 // CHECK-NEXT:   %1 = call ptr @PyObject_GetAttrString(ptr %0, ptr @1)

--- a/cl/_testpy/pow/in.go
+++ b/cl/_testpy/pow/in.go
@@ -7,7 +7,7 @@ import (
 	"github.com/goplus/lib/py/math"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testpy/pow.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @PyFloat_FromDouble(double 2.000000e+00)
 // CHECK-NEXT:   %1 = call ptr @PyFloat_FromDouble(double 3.000000e+00)

--- a/cl/_testrt/abinamed/in.go
+++ b/cl/_testrt/abinamed/in.go
@@ -7,31 +7,31 @@ import (
 	"github.com/goplus/llgo/runtime/abi"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/abinamed.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/abinamed.T" zeroinitializer, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/abinamed.T", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/cl/_testrt/abinamed.toEface"(%"{{.*}}/runtime/internal/runtime.eface" %1)
+// CHECK-NEXT:   store %main.T zeroinitializer, ptr %0, align 8
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.T, ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %2 = call ptr @main.toEface(%"{{.*}}/runtime/internal/runtime.eface" %1)
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 72)
 // CHECK-NEXT:   store %"{{.*}}/runtime/abi.Type" zeroinitializer, ptr %3, align 8
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/runtime/abi.Type", ptr undef }, ptr %3, 1
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/cl/_testrt/abinamed.toEface"(%"{{.*}}/runtime/internal/runtime.eface" %4)
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %5 = call ptr @main.toEface(%"{{.*}}/runtime/internal/runtime.eface" %4)
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %7 = load ptr, ptr %6, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %7)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %9 = load ptr, ptr %8, align 8
 // CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %9, i32 0, i32 10
 // CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %11)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %13)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %14 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %15 = load ptr, ptr %14, align 8
 // CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %15, i32 0, i32 10
 // CHECK-NEXT:   %17 = load ptr, ptr %16, align 8
@@ -39,7 +39,7 @@ import (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %18 = alloca %"{{.*}}/runtime/abi.StructField", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %19 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %20 = load ptr, ptr %19, align 8
 // CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %20)
 // CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %21, i32 0, i32 2
@@ -53,7 +53,7 @@ import (
 // CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %28, ptr %18, align 8
 // CHECK-NEXT:   %29 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %18, i32 0, i32 1
 // CHECK-NEXT:   %30 = load ptr, ptr %29, align 8
-// CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %31 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %32 = load ptr, ptr %31, align 8
 // CHECK-NEXT:   %33 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %32, i32 0, i32 10
 // CHECK-NEXT:   %34 = load ptr, ptr %33, align 8
@@ -71,7 +71,7 @@ import (
 // CHECK-NEXT:   %38 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %18, i32 0, i32 1
 // CHECK-NEXT:   %39 = load ptr, ptr %38, align 8
 // CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %39)
-// CHECK-NEXT:   %41 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %41 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %42 = load ptr, ptr %41, align 8
 // CHECK-NEXT:   %43 = icmp ne ptr %40, %42
 // CHECK-NEXT:   br i1 %43, label %_llgo_3, label %_llgo_4
@@ -86,7 +86,7 @@ import (
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %46 = alloca %"{{.*}}/runtime/abi.StructField", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %46, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %47 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %47 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %48 = load ptr, ptr %47, align 8
 // CHECK-NEXT:   %49 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %48)
 // CHECK-NEXT:   %50 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %49, i32 0, i32 2
@@ -100,7 +100,7 @@ import (
 // CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %56, ptr %46, align 8
 // CHECK-NEXT:   %57 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %46, i32 0, i32 1
 // CHECK-NEXT:   %58 = load ptr, ptr %57, align 8
-// CHECK-NEXT:   %59 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %59 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %60 = load ptr, ptr %59, align 8
 // CHECK-NEXT:   %61 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %60, i32 0, i32 10
 // CHECK-NEXT:   %62 = load ptr, ptr %61, align 8
@@ -118,7 +118,7 @@ import (
 // CHECK-NEXT:   %66 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %46, i32 0, i32 1
 // CHECK-NEXT:   %67 = load ptr, ptr %66, align 8
 // CHECK-NEXT:   %68 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %67)
-// CHECK-NEXT:   %69 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %69 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %70 = load ptr, ptr %69, align 8
 // CHECK-NEXT:   %71 = icmp ne ptr %68, %70
 // CHECK-NEXT:   br i1 %71, label %_llgo_7, label %_llgo_8
@@ -133,7 +133,7 @@ import (
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_6
 // CHECK-NEXT:   %74 = alloca %"{{.*}}/runtime/abi.StructField", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %74, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %75 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %75 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %76 = load ptr, ptr %75, align 8
 // CHECK-NEXT:   %77 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %76)
 // CHECK-NEXT:   %78 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %77, i32 0, i32 2
@@ -147,7 +147,7 @@ import (
 // CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %84, ptr %74, align 8
 // CHECK-NEXT:   %85 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %74, i32 0, i32 1
 // CHECK-NEXT:   %86 = load ptr, ptr %85, align 8
-// CHECK-NEXT:   %87 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %87 = getelementptr inbounds %main.eface, ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %88 = load ptr, ptr %87, align 8
 // CHECK-NEXT:   %89 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %88)
 // CHECK-NEXT:   %90 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %89, i32 0, i32 2
@@ -172,7 +172,7 @@ import (
 // CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_8
 // CHECK-NEXT:   %101 = alloca %"{{.*}}/runtime/abi.StructField", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %101, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %102 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %102 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %103 = load ptr, ptr %102, align 8
 // CHECK-NEXT:   %104 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %103)
 // CHECK-NEXT:   %105 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %104, i32 0, i32 2
@@ -187,7 +187,7 @@ import (
 // CHECK-NEXT:   %112 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %101, i32 0, i32 1
 // CHECK-NEXT:   %113 = load ptr, ptr %112, align 8
 // CHECK-NEXT:   %114 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %113)
-// CHECK-NEXT:   %115 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %115 = getelementptr inbounds %main.eface, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %116 = load ptr, ptr %115, align 8
 // CHECK-NEXT:   %117 = icmp ne ptr %114, %116
 // CHECK-NEXT:   br i1 %117, label %_llgo_11, label %_llgo_12
@@ -248,7 +248,7 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/abinamed.toEface"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
+// CHECK-LABEL: define ptr @main.toEface(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %0, ptr %1, align 8

--- a/cl/_testrt/abitype/in.go
+++ b/cl/_testrt/abitype/in.go
@@ -7,14 +7,14 @@ import (
 	"github.com/goplus/llgo/runtime/abi"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/abitype.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 4)
 // CHECK-NEXT:   store i32 0, ptr %1, align 4
 // CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int32, ptr undef }, ptr %1, 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %2, ptr %0, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/abitype.eface", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.eface, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
 // CHECK-NEXT:   %5 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/abi.(*Type).String"(ptr %4)
 // CHECK-NEXT:   %6 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %5, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 })
@@ -33,7 +33,7 @@ import (
 // CHECK-NEXT:   store i8 0, ptr %10, align 1
 // CHECK-NEXT:   %11 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_uint8, ptr undef }, ptr %10, 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %11, ptr %0, align 8
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testrt/abitype.eface", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.eface, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
 // CHECK-NEXT:   %14 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/abi.(*Type).String"(ptr %13)
 // CHECK-NEXT:   %15 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %14, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 5 })

--- a/cl/_testrt/alloca/in.go
+++ b/cl/_testrt/alloca/in.go
@@ -7,7 +7,7 @@ import (
 
 // CHECK: {{^}}@0 = private unnamed_addr constant [4 x i8] c"Hi\0A\00", align 1{{$}}
 // CHECK: {{^}}@1 = private unnamed_addr constant [3 x i8] c"%s\00", align 1{{$}}
-// CHECK-LABEL: define void @"{{.*}}alloca.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 func main() {
 	s := c.Str("Hi\n")
 	s2 := c.Alloca(4)

--- a/cl/_testrt/allocstr/in.go
+++ b/cl/_testrt/allocstr/in.go
@@ -8,7 +8,7 @@ import (
 // CHECK: {{^}}%"{{.*}}/runtime/internal/runtime.String" = type { ptr, i64 }{{$}}
 // CHECK: {{^}}@0 = private unnamed_addr constant [12 x i8] c"Hello world\0A", align 1{{$}}
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/allocstr.hello"(){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.hello(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 12 }
 // CHECK-NEXT: }
@@ -16,9 +16,9 @@ func hello() string {
 	return "Hello world\n"
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/allocstr.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/allocstr.hello"()
+// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.String" @main.hello()
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %0, 1
 // CHECK-NEXT:   %2 = add i64 %1, 1
 // CHECK-NEXT:   %3 = alloca i8, i64 %2, align 1

--- a/cl/_testrt/any/in.go
+++ b/cl/_testrt/any/in.go
@@ -10,7 +10,7 @@ import (
 // CHECK: @3 = private unnamed_addr constant [7 x i8] c"%s %d\0A\00", align 1
 // CHECK: @4 = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/any.hi"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
+// CHECK-LABEL: define ptr @main.hi(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %0, 0
 // CHECK-NEXT:   %2 = icmp eq ptr %1, @"*_llgo_int8"
@@ -29,7 +29,7 @@ func hi(a any) *c.Char {
 	return a.(*c.Char)
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/any.incVal"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.incVal(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %0, 0
 // CHECK-NEXT:   %2 = icmp eq ptr %1, @_llgo_int
@@ -54,26 +54,26 @@ func main() {
 	c.Printf(c.Str("%s %d\n"), hi(c.Str("Hello")), incVal(100))
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/any.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/any.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/any.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/any.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testrt/any.hi"(%"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_int8", ptr @4 })
+// CHECK-NEXT:   %0 = call ptr @main.hi(%"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_int8", ptr @4 })
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 100, ptr %1, align 8
 // CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %1, 1
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/any.incVal"(%"{{.*}}/runtime/internal/runtime.eface" %2)
+// CHECK-NEXT:   %3 = call i64 @main.incVal(%"{{.*}}/runtime/internal/runtime.eface" %2)
 // CHECK-NEXT:   %4 = call i32 (ptr, ...) @printf(ptr @3, ptr %0, i64 %3)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/asm/in.go
+++ b/cl/_testrt/asm/in.go
@@ -6,7 +6,7 @@ import _ "unsafe"
 //go:linkname asm llgo.asm
 func asm(instruction string)
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/asm.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void asm sideeffect "nop", ""()
 // CHECK-NEXT:   ret void

--- a/cl/_testrt/asmfull/in.go
+++ b/cl/_testrt/asmfull/in.go
@@ -6,7 +6,7 @@ import _ "unsafe"
 //go:linkname asmFull llgo.asm
 func asmFull(instruction string, regs map[string]any) uintptr
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/asmfull.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void asm sideeffect "nop", ""()
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_string]_llgo_any", i64 1)

--- a/cl/_testrt/builtin/in.go
+++ b/cl/_testrt/builtin/in.go
@@ -29,7 +29,7 @@ const (
 	fracMask = 1<<shift - 1
 )
 
-// CHECK-LABEL: define double @"{{.*}}/cl/_testrt/builtin.Float64frombits"(i64 %0){{.*}} {
+// CHECK-LABEL: define double @main.Float64frombits(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 %0, ptr %1, align 8
@@ -39,7 +39,7 @@ const (
 
 func Float64frombits(b uint64) float64 { return *(*float64)(unsafe.Pointer(&b)) }
 
-// CHECK-LABEL: define double @"{{.*}}/cl/_testrt/builtin.Inf"(i64 %0){{.*}} {
+// CHECK-LABEL: define double @main.Inf(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp sge i64 %0, 0
 // CHECK-NEXT:   br i1 %1, label %_llgo_1, label %_llgo_3
@@ -49,7 +49,7 @@ func Float64frombits(b uint64) float64 { return *(*float64)(unsafe.Pointer(&b)) 
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_3, %_llgo_1
 // CHECK-NEXT:   %2 = phi i64 [ 9218868437227405312, %_llgo_1 ], [ -4503599627370496, %_llgo_3 ]
-// CHECK-NEXT:   %3 = call double @"{{.*}}/cl/_testrt/builtin.Float64frombits"(i64 %2)
+// CHECK-NEXT:   %3 = call double @main.Float64frombits(i64 %2)
 // CHECK-NEXT:   ret double %3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
@@ -67,7 +67,7 @@ func Inf(sign int) float64 {
 	return Float64frombits(v)
 }
 
-// CHECK-LABEL: define i1 @"{{.*}}/cl/_testrt/builtin.IsNaN"(double %0){{.*}} {
+// CHECK-LABEL: define i1 @main.IsNaN(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = fcmp une double %0, %0
 // CHECK-NEXT:   ret i1 %1
@@ -77,16 +77,16 @@ func IsNaN(f float64) (is bool) {
 	return f != f
 }
 
-// CHECK-LABEL: define double @"{{.*}}/cl/_testrt/builtin.NaN"(){{.*}} {
+// CHECK-LABEL: define double @main.NaN(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call double @"{{.*}}/cl/_testrt/builtin.Float64frombits"(i64 9221120237041090561)
+// CHECK-NEXT:   %0 = call double @main.Float64frombits(i64 9221120237041090561)
 // CHECK-NEXT:   ret double %0
 // CHECK-NEXT: }
 
 // NaN returns an IEEE 754 “not-a-number” value.
 func NaN() float64 { return Float64frombits(uvnan) }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/builtin.demo"(){{.*}} {
+// CHECK-LABEL: define void @main.demo(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -94,7 +94,7 @@ func NaN() float64 { return Float64frombits(uvnan) }
 func demo() {
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/builtin.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
 // CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -266,7 +266,7 @@ func demo() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %89 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %90 = getelementptr inbounds { ptr, ptr }, ptr %89, i64 0
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testrt/builtin.main$1", ptr null }, ptr %90, align 8
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null }, ptr %90, align 8
 // CHECK-NEXT:   %91 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %89, 0
 // CHECK-NEXT:   %92 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %91, i64 1, 1
 // CHECK-NEXT:   %93 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %92, i64 1, 2
@@ -355,12 +355,12 @@ func demo() {
 // CHECK-NEXT:   %132 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %133 = getelementptr inbounds { ptr }, ptr %132, i32 0, i32 0
 // CHECK-NEXT:   store ptr %103, ptr %133, align 8
-// CHECK-NEXT:   %134 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/builtin.main$3", ptr undef }, ptr %132, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @"{{.*}}/cl/_testrt/builtin.demo")
+// CHECK-NEXT:   %134 = insertvalue { ptr, ptr } { ptr @"main.main$3", ptr undef }, ptr %132, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @main.demo)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @"{{.*}}/cl/_testrt/builtin.demo")
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @main.demo)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @"{{.*}}/cl/_testrt/builtin.main$2")
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @"main.main$2")
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   %135 = extractvalue { ptr, ptr } %134, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %135)
@@ -384,12 +384,12 @@ func demo() {
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %142 = call double @"{{.*}}/cl/_testrt/builtin.Inf"(i64 1)
-// CHECK-NEXT:   %143 = call double @"{{.*}}/cl/_testrt/builtin.Inf"(i64 -1)
-// CHECK-NEXT:   %144 = call double @"{{.*}}/cl/_testrt/builtin.NaN"()
-// CHECK-NEXT:   %145 = call double @"{{.*}}/cl/_testrt/builtin.NaN"()
-// CHECK-NEXT:   %146 = call i1 @"{{.*}}/cl/_testrt/builtin.IsNaN"(double %145)
-// CHECK-NEXT:   %147 = call i1 @"{{.*}}/cl/_testrt/builtin.IsNaN"(double 1.000000e+00)
+// CHECK-NEXT:   %142 = call double @main.Inf(i64 1)
+// CHECK-NEXT:   %143 = call double @main.Inf(i64 -1)
+// CHECK-NEXT:   %144 = call double @main.NaN()
+// CHECK-NEXT:   %145 = call double @main.NaN()
+// CHECK-NEXT:   %146 = call i1 @main.IsNaN(double %145)
+// CHECK-NEXT:   %147 = call i1 @main.IsNaN(double 1.000000e+00)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintFloat"(double %142)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintFloat"(double %143)
@@ -477,7 +477,7 @@ func main() {
 	println(data)
 	fns := []func(){}
 
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/builtin.main$1"(){{.*}} {
+	// CHECK-LABEL: define void @"main.main$1"(){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   ret void
 	// CHECK-NEXT: }
@@ -494,7 +494,7 @@ func main() {
 
 	fn1 := demo
 
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/builtin.main$2"(){{.*}} {
+	// CHECK-LABEL: define void @"main.main$2"(){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 2 })
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -505,7 +505,7 @@ func main() {
 		println("fn")
 	}
 
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/builtin.main$3"(ptr %0){{.*}} {
+	// CHECK-LABEL: define void @"main.main$3"(ptr %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 	// CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
@@ -535,9 +535,9 @@ func main() {
 	println(s1 == "abc", s1 == s2, s1 != s2, s1 < s2, s1 <= s2, s1 > s2, s1 >= s2)
 }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/builtin.main$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.main$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/builtin.main$1"()
+// CHECK-NEXT:   tail call void @"main.main$1"()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 

--- a/cl/_testrt/callback/in.go
+++ b/cl/_testrt/callback/in.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/callback.callback"(ptr %0, { ptr, ptr } %1){{.*}} {
+// CHECK-LABEL: define void @main.callback(ptr %0, { ptr, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = extractvalue { ptr, ptr } %1, 1
 // CHECK-NEXT:   %3 = extractvalue { ptr, ptr } %1, 0
@@ -16,10 +16,10 @@ func callback(msg *c.Char, f func(*c.Char)) {
 	f(msg)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/callback.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/callback.callback"(ptr @0, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/callback.print", ptr null })
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/callback.callback"(ptr @1, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/callback.print", ptr null })
+// CHECK-NEXT:   call void @main.callback(ptr @0, { ptr, ptr } { ptr @__llgo_stub.main.print, ptr null })
+// CHECK-NEXT:   call void @main.callback(ptr @1, { ptr, ptr } { ptr @__llgo_stub.main.print, ptr null })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {
@@ -27,15 +27,15 @@ func main() {
 	callback(c.Str("callback\n"), print)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/callback.print"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @main.print(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call i32 (ptr, ...) @printf(ptr %0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/callback.print"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @__llgo_stub.main.print(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/callback.print"(ptr %1)
+// CHECK-NEXT:   tail call void @main.print(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func print(msg *c.Char) {

--- a/cl/_testrt/cast/in.go
+++ b/cl/_testrt/cast/in.go
@@ -5,7 +5,7 @@ package main
 
 // CHECK: @0 = private unnamed_addr constant [5 x i8] c"error", align 1
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt32Fto32"(float %0, i32 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt32Fto32(float %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = fcmp ole float %0, 0xC1E0000000000000
 // CHECK-NEXT:   %3 = fcmp oge float %0, 0x41E0000000000000
@@ -37,7 +37,7 @@ func cvt32Fto32(a float32, b int32) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt32Fto32U"(float %0, i32 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt32Fto32U(float %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = fcmp ole float %0, 0xC3E0000000000000
 // CHECK-NEXT:   %3 = fcmp oge float %0, 0x43E0000000000000
@@ -70,7 +70,7 @@ func cvt32Fto32U(a float32, b uint32) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt32Fto64F"(float %0, double %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt32Fto64F(float %0, double %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = fpext float %0 to double
 // CHECK-NEXT:   %3 = fcmp une double %2, %1
@@ -93,7 +93,7 @@ func cvt32Fto64F(a float32, b float64) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt32Fto8"(float %0, i8 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt32Fto8(float %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = fcmp ole float %0, 0xC1E0000000000000
 // CHECK-NEXT:   %3 = fcmp oge float %0, 0x41E0000000000000
@@ -126,7 +126,7 @@ func cvt32Fto8(a float32, b int8) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt32Fto8U"(float %0, i8 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt32Fto8U(float %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = fcmp ole float %0, 0xC1E0000000000000
 // CHECK-NEXT:   %3 = fcmp oge float %0, 0x41E0000000000000
@@ -159,7 +159,7 @@ func cvt32Fto8U(a float32, b uint8) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt32to64"(i32 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt32to64(i32 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = sext i32 %0 to i64
 // CHECK-NEXT:   %3 = icmp ne i64 %2, %1
@@ -182,7 +182,7 @@ func cvt32to64(a int32, b int64) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt64Fto32F"(double %0, float %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt64Fto32F(double %0, float %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = fptrunc double %0 to float
 // CHECK-NEXT:   %3 = fcmp une float %2, %1
@@ -205,7 +205,7 @@ func cvt64Fto32F(a float64, b float32) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt64Uto64F"(i64 %0, double %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt64Uto64F(i64 %0, double %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = uitofp i64 %0 to double
 // CHECK-NEXT:   %3 = fcmp une double %2, %1
@@ -228,7 +228,7 @@ func cvt64Uto64F(a uint64, b float64) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt64to64F"(i64 %0, double %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt64to64F(i64 %0, double %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = sitofp i64 %0 to double
 // CHECK-NEXT:   %3 = fcmp une double %2, %1
@@ -251,7 +251,7 @@ func cvt64to64F(a int64, b float64) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt64to8"(i64 %0, i8 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt64to8(i64 %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = trunc i64 %0 to i8
 // CHECK-NEXT:   %3 = icmp ne i8 %2, %1
@@ -274,7 +274,7 @@ func cvt64to8(a int64, b int8) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt64to8U"(i64 %0, i8 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvt64to8U(i64 %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = trunc i64 %0 to i8
 // CHECK-NEXT:   %3 = icmp ne i8 %2, %1
@@ -297,7 +297,7 @@ func cvt64to8U(a int, b uint8) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvtFtoUintptr"(double %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvtFtoUintptr(double %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = fcmp olt double %0, 0.000000e+00
 // CHECK-NEXT:   %3 = fcmp oge double %0, 0x43F0000000000000
@@ -329,7 +329,7 @@ func cvtFtoUintptr(a float64, b uintptr) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvtUinptr"(i32 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @main.cvtUinptr(i32 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = sext i32 %0 to i64
 // CHECK-NEXT:   %3 = icmp ne i64 %2, %1
@@ -448,75 +448,75 @@ func main() {
 	cvtFtoUintptr(1e5, 100000)
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/cast.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/cast.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8"(i64 0, i8 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8"(i64 127, i8 127)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8"(i64 128, i8 -128)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8"(i64 -128, i8 -128)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8"(i64 -129, i8 127)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8"(i64 256, i8 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8U"(i64 0, i8 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8U"(i64 255, i8 -1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8U"(i64 256, i8 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8U"(i64 257, i8 1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to8U"(i64 -1, i8 -1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8"(float 0x3FB99999A0000000, i8 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8"(float 0x405FC66660000000, i8 127)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8"(float 0x4060033340000000, i8 -128)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8"(float 0xC060033340000000, i8 -128)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8"(float 0xC060233340000000, i8 127)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8"(float 0x40700199A0000000, i8 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8U"(float 0.000000e+00, i8 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8U"(float 2.550000e+02, i8 -1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8U"(float 2.560000e+02, i8 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8U"(float 2.570000e+02, i8 1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto8U"(float -1.000000e+00, i8 -1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32"(float 0.000000e+00, i32 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32"(float 1.500000e+00, i32 1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32"(float 0x41D1194D80000000, i32 1147483648)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32"(float 0xC1E0000000000000, i32 -2147483648)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32U"(float 0.000000e+00, i32 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32U"(float 1.500000e+00, i32 1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32U"(float 0x41F0000000000000, i32 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32U"(float 0x41F3B9ACA0000000, i32 1000000000)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32U"(float 0xC1F0000000000000, i32 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32U"(float 0xC1D34BE880000000, i32 -1294967296)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto32U"(float 0xBFF19999A0000000, i32 -1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto64F"(float 0.000000e+00, double 0.000000e+00)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto64F"(float 1.500000e+00, double 1.500000e+00)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto64F"(float 1.000000e+10, double 1.000000e+10)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32Fto64F"(float -1.000000e+10, double -1.000000e+10)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64Fto32F"(double 0.000000e+00, float 0.000000e+00)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64Fto32F"(double 1.500000e+00, float 1.500000e+00)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64Fto32F"(double 1.000000e+10, float 1.000000e+10)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64Fto32F"(double -1.000000e+10, float -1.000000e+10)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to64F"(i64 0, double 0.000000e+00)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to64F"(i64 10000000000, double 1.000000e+10)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to64F"(i64 9223372036854775807, double 0x43E0000000000000)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64to64F"(i64 -9223372036854775807, double 0xC3E0000000000000)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64Uto64F"(i64 0, double 0.000000e+00)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64Uto64F"(i64 10000000000, double 1.000000e+10)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64Uto64F"(i64 9223372036854775807, double 0x43E0000000000000)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt64Uto64F"(i64 -1, double 0x43F0000000000000)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32to64"(i32 0, i64 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvt32to64"(i32 2147483647, i64 2147483647)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvtUinptr"(i32 1024, i64 1024)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvtFtoUintptr"(double 1.000000e+02, i64 100)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvtFtoUintptr"(double 0.000000e+00, i64 0)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/cast.cvtFtoUintptr"(double 1.000000e+05, i64 100000)
+// CHECK-NEXT:   call void @main.cvt64to8(i64 0, i8 0)
+// CHECK-NEXT:   call void @main.cvt64to8(i64 127, i8 127)
+// CHECK-NEXT:   call void @main.cvt64to8(i64 128, i8 -128)
+// CHECK-NEXT:   call void @main.cvt64to8(i64 -128, i8 -128)
+// CHECK-NEXT:   call void @main.cvt64to8(i64 -129, i8 127)
+// CHECK-NEXT:   call void @main.cvt64to8(i64 256, i8 0)
+// CHECK-NEXT:   call void @main.cvt64to8U(i64 0, i8 0)
+// CHECK-NEXT:   call void @main.cvt64to8U(i64 255, i8 -1)
+// CHECK-NEXT:   call void @main.cvt64to8U(i64 256, i8 0)
+// CHECK-NEXT:   call void @main.cvt64to8U(i64 257, i8 1)
+// CHECK-NEXT:   call void @main.cvt64to8U(i64 -1, i8 -1)
+// CHECK-NEXT:   call void @main.cvt32Fto8(float 0x3FB99999A0000000, i8 0)
+// CHECK-NEXT:   call void @main.cvt32Fto8(float 0x405FC66660000000, i8 127)
+// CHECK-NEXT:   call void @main.cvt32Fto8(float 0x4060033340000000, i8 -128)
+// CHECK-NEXT:   call void @main.cvt32Fto8(float 0xC060033340000000, i8 -128)
+// CHECK-NEXT:   call void @main.cvt32Fto8(float 0xC060233340000000, i8 127)
+// CHECK-NEXT:   call void @main.cvt32Fto8(float 0x40700199A0000000, i8 0)
+// CHECK-NEXT:   call void @main.cvt32Fto8U(float 0.000000e+00, i8 0)
+// CHECK-NEXT:   call void @main.cvt32Fto8U(float 2.550000e+02, i8 -1)
+// CHECK-NEXT:   call void @main.cvt32Fto8U(float 2.560000e+02, i8 0)
+// CHECK-NEXT:   call void @main.cvt32Fto8U(float 2.570000e+02, i8 1)
+// CHECK-NEXT:   call void @main.cvt32Fto8U(float -1.000000e+00, i8 -1)
+// CHECK-NEXT:   call void @main.cvt32Fto32(float 0.000000e+00, i32 0)
+// CHECK-NEXT:   call void @main.cvt32Fto32(float 1.500000e+00, i32 1)
+// CHECK-NEXT:   call void @main.cvt32Fto32(float 0x41D1194D80000000, i32 1147483648)
+// CHECK-NEXT:   call void @main.cvt32Fto32(float 0xC1E0000000000000, i32 -2147483648)
+// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0.000000e+00, i32 0)
+// CHECK-NEXT:   call void @main.cvt32Fto32U(float 1.500000e+00, i32 1)
+// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0x41F0000000000000, i32 0)
+// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0x41F3B9ACA0000000, i32 1000000000)
+// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0xC1F0000000000000, i32 0)
+// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0xC1D34BE880000000, i32 -1294967296)
+// CHECK-NEXT:   call void @main.cvt32Fto32U(float 0xBFF19999A0000000, i32 -1)
+// CHECK-NEXT:   call void @main.cvt32Fto64F(float 0.000000e+00, double 0.000000e+00)
+// CHECK-NEXT:   call void @main.cvt32Fto64F(float 1.500000e+00, double 1.500000e+00)
+// CHECK-NEXT:   call void @main.cvt32Fto64F(float 1.000000e+10, double 1.000000e+10)
+// CHECK-NEXT:   call void @main.cvt32Fto64F(float -1.000000e+10, double -1.000000e+10)
+// CHECK-NEXT:   call void @main.cvt64Fto32F(double 0.000000e+00, float 0.000000e+00)
+// CHECK-NEXT:   call void @main.cvt64Fto32F(double 1.500000e+00, float 1.500000e+00)
+// CHECK-NEXT:   call void @main.cvt64Fto32F(double 1.000000e+10, float 1.000000e+10)
+// CHECK-NEXT:   call void @main.cvt64Fto32F(double -1.000000e+10, float -1.000000e+10)
+// CHECK-NEXT:   call void @main.cvt64to64F(i64 0, double 0.000000e+00)
+// CHECK-NEXT:   call void @main.cvt64to64F(i64 10000000000, double 1.000000e+10)
+// CHECK-NEXT:   call void @main.cvt64to64F(i64 9223372036854775807, double 0x43E0000000000000)
+// CHECK-NEXT:   call void @main.cvt64to64F(i64 -9223372036854775807, double 0xC3E0000000000000)
+// CHECK-NEXT:   call void @main.cvt64Uto64F(i64 0, double 0.000000e+00)
+// CHECK-NEXT:   call void @main.cvt64Uto64F(i64 10000000000, double 1.000000e+10)
+// CHECK-NEXT:   call void @main.cvt64Uto64F(i64 9223372036854775807, double 0x43E0000000000000)
+// CHECK-NEXT:   call void @main.cvt64Uto64F(i64 -1, double 0x43F0000000000000)
+// CHECK-NEXT:   call void @main.cvt32to64(i32 0, i64 0)
+// CHECK-NEXT:   call void @main.cvt32to64(i32 2147483647, i64 2147483647)
+// CHECK-NEXT:   call void @main.cvtUinptr(i32 1024, i64 1024)
+// CHECK-NEXT:   call void @main.cvtFtoUintptr(double 1.000000e+02, i64 100)
+// CHECK-NEXT:   call void @main.cvtFtoUintptr(double 0.000000e+00, i64 0)
+// CHECK-NEXT:   call void @main.cvtFtoUintptr(double 1.000000e+05, i64 100000)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/closure/in.go
+++ b/cl/_testrt/closure/in.go
@@ -5,22 +5,22 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closure.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/closure.main$1"(i64 100, i64 200)
+// CHECK-NEXT:   call void @"main.main$1"(i64 100, i64 200)
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closure.main$2", ptr null }, ptr %0, align 8
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.main.main$2", ptr null }, ptr %0, align 8
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/closure.main$3", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.main$3", ptr undef }, ptr %1, 1
 // CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %3, 1
 // CHECK-NEXT:   %5 = extractvalue { ptr, ptr } %3, 0
 // CHECK-NEXT:   call void %5(ptr %4)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closure.main$1"(i64 %0, i64 %1){{.*}} {
+	// CHECK-LABEL: define void @"main.main$1"(i64 %0, i64 %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = call i32 (ptr, ...) @printf(ptr @0, i64 %0, i64 %1)
 	// CHECK-NEXT:   ret void
@@ -29,7 +29,7 @@ func main() {
 		c.Printf(c.Str("%d %d\n"), n1, n2)
 	}(100, 200)
 
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closure.main$2"(i64 %0, i64 %1){{.*}} {
+	// CHECK-LABEL: define void @"main.main$2"(i64 %0, i64 %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = call i32 (ptr, ...) @printf(ptr @1, i64 %0, i64 %1)
 	// CHECK-NEXT:   ret void
@@ -38,7 +38,7 @@ func main() {
 		c.Printf(c.Str("%d %d\n"), n1, n2)
 	}
 
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closure.main$3"(ptr %0){{.*}} {
+	// CHECK-LABEL: define void @"main.main$3"(ptr %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 	// CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
@@ -54,8 +54,8 @@ func main() {
 	fn2()
 }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closure.main$2"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.main$2"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/closure.main$2"(i64 %1, i64 %2)
+// CHECK-NEXT:   tail call void @"main.main$2"(i64 %1, i64 %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/closurebound/in.go
+++ b/cl/_testrt/closurebound/in.go
@@ -11,7 +11,7 @@ var my = demo2{}.encode
 type demo1 struct {
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.demo1.encode(%main.demo1 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret i64 1
 // CHECK-NEXT: }
@@ -35,55 +35,55 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.(*demo1).encode"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*demo1).encode"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 52 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 6 })
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" zeroinitializer)
+// CHECK-NEXT:   %3 = call i64 @main.demo1.encode(%main.demo1 zeroinitializer)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.demo2.encode(%main.demo2 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret i64 2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.(*demo2).encode"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*demo2).encode"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 52 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 6 })
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" zeroinitializer)
+// CHECK-NEXT:   %3 = call i64 @main.demo2.encode(%main.demo2 zeroinitializer)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closurebound.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/closurebound.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/closurebound.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
-// CHECK-NEXT:   %2 = getelementptr inbounds { %"{{.*}}/cl/_testrt/closurebound.demo2" }, ptr %1, i32 0, i32 0
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/closurebound.demo2" zeroinitializer, ptr %2, align 1
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/closurebound.demo2.encode$bound", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   store { ptr, ptr } %3, ptr @"{{.*}}/cl/_testrt/closurebound.my", align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { %main.demo2 }, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.demo2 zeroinitializer, ptr %2, align 1
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.demo2.encode$bound", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   store { ptr, ptr } %3, ptr @main.my, align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closurebound.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
-// CHECK-NEXT:   %1 = getelementptr inbounds { %"{{.*}}/cl/_testrt/closurebound.demo1" }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/closurebound.demo1" zeroinitializer, ptr %1, align 1
-// CHECK-NEXT:   %2 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/closurebound.demo1.encode$bound", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %1 = getelementptr inbounds { %main.demo1 }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store %main.demo1 zeroinitializer, ptr %1, align 1
+// CHECK-NEXT:   %2 = insertvalue { ptr, ptr } { ptr @"main.demo1.encode$bound", ptr undef }, ptr %0, 1
 // CHECK-NEXT:   %3 = extractvalue { ptr, ptr } %2, 1
 // CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %2, 0
 // CHECK-NEXT:   %5 = call i64 %4(ptr %3)
@@ -101,18 +101,18 @@ func main() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode$bound"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.demo2.encode$bound"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" zeroinitializer)
+// CHECK-NEXT:   %2 = call i64 @main.demo2.encode(%main.demo2 zeroinitializer)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode$bound"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.demo1.encode$bound"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" zeroinitializer)
+// CHECK-NEXT:   %2 = call i64 @main.demo1.encode(%main.demo1 zeroinitializer)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }

--- a/cl/_testrt/closureconv/in.go
+++ b/cl/_testrt/closureconv/in.go
@@ -9,10 +9,10 @@ type Call struct {
 	n  int
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closureconv.(*Call).add"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*Call).add"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %3 = add i64 %1, %2
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/closureconv.Call", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.Call, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %5 = load i64, ptr %4, align 8
 // CHECK-NEXT:   %6 = add i64 %3, %5
 // CHECK-NEXT:   ret i64 %6
@@ -21,7 +21,7 @@ func (c *Call) add(a int, b int) int {
 	return a + b + c.n
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closureconv.add"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.add(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
@@ -30,23 +30,23 @@ func add(a int, b int) int {
 	return a + b
 }
 
-// CHECK-LABEL: define %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo1"(i64 %0){{.*}} {
+// CHECK-LABEL: define %main.Func @main.demo1(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/closureconv.Call", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   store i64 %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %4 = getelementptr inbounds { ptr }, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   store ptr %1, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/closureconv.(*Call).add$bound", ptr undef }, ptr %3, 1
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testrt/closureconv.Call", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %7 = alloca %"{{.*}}/cl/_testrt/closureconv.Func", align 8
+// CHECK-NEXT:   %5 = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr %3, 1
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %7 = alloca %main.Func, align 8
 // CHECK-NEXT:   store { ptr, ptr } %5, ptr %7, align 8
-// CHECK-NEXT:   %8 = load %"{{.*}}/cl/_testrt/closureconv.Func", ptr %7, align 8
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/closureconv.Func" %8, ptr %6, align 8
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/closureconv.Call", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testrt/closureconv.Func", ptr %9, align 8
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testrt/closureconv.Func" %10
+// CHECK-NEXT:   %8 = load %main.Func, ptr %7, align 8
+// CHECK-NEXT:   store %main.Func %8, ptr %6, align 8
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %10 = load %main.Func, ptr %9, align 8
+// CHECK-NEXT:   ret %main.Func %10
 // CHECK-NEXT: }
 func demo1(n int) Func {
 	m := &Call{n: n}
@@ -54,17 +54,17 @@ func demo1(n int) Func {
 	return m.fn
 }
 
-// CHECK-LABEL: define %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo2"(){{.*}} {
+// CHECK-LABEL: define %main.Func @main.demo2(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/closureconv.(*Call).add$bound", ptr undef }, ptr %1, 1
-// CHECK-NEXT:   %4 = alloca %"{{.*}}/cl/_testrt/closureconv.Func", align 8
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.(*Call).add$bound", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %4 = alloca %main.Func, align 8
 // CHECK-NEXT:   store { ptr, ptr } %3, ptr %4, align 8
-// CHECK-NEXT:   %5 = load %"{{.*}}/cl/_testrt/closureconv.Func", ptr %4, align 8
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testrt/closureconv.Func" %5
+// CHECK-NEXT:   %5 = load %main.Func, ptr %4, align 8
+// CHECK-NEXT:   ret %main.Func %5
 // CHECK-NEXT: }
 
 func demo2() Func {
@@ -72,21 +72,21 @@ func demo2() Func {
 	return m.add
 }
 
-// CHECK-LABEL: define %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo3"(){{.*}} {
+// CHECK-LABEL: define %main.Func @main.demo3(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testrt/closureconv.Func" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closureconv.add", ptr null }
+// CHECK-NEXT:   ret %main.Func { ptr @__llgo_stub.main.add, ptr null }
 // CHECK-NEXT: }
 
 func demo3() Func {
 	return add
 }
 
-// CHECK-LABEL: define %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo4"(){{.*}} {
+// CHECK-LABEL: define %main.Func @main.demo4(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testrt/closureconv.Func" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closureconv.demo4$1", ptr null }
+// CHECK-NEXT:   ret %main.Func { ptr @"__llgo_stub.main.demo4$1", ptr null }
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closureconv.demo4$1"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.demo4$1"(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
@@ -95,21 +95,21 @@ func demo4() Func {
 	return func(a, b int) int { return a + b }
 }
 
-// CHECK-LABEL: define %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo5"(i64 %0){{.*}} {
+// CHECK-LABEL: define %main.Func @main.demo5(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %3 = getelementptr inbounds { ptr }, ptr %2, i32 0, i32 0
 // CHECK-NEXT:   store ptr %1, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/closureconv.demo5$1", ptr undef }, ptr %2, 1
-// CHECK-NEXT:   %5 = alloca %"{{.*}}/cl/_testrt/closureconv.Func", align 8
+// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"main.demo5$1", ptr undef }, ptr %2, 1
+// CHECK-NEXT:   %5 = alloca %main.Func, align 8
 // CHECK-NEXT:   store { ptr, ptr } %4, ptr %5, align 8
-// CHECK-NEXT:   %6 = load %"{{.*}}/cl/_testrt/closureconv.Func", ptr %5, align 8
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testrt/closureconv.Func" %6
+// CHECK-NEXT:   %6 = load %main.Func, ptr %5, align 8
+// CHECK-NEXT:   ret %main.Func %6
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closureconv.demo5$1"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define i64 @"main.demo5$1"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %3 = add i64 %1, %2
 // CHECK-NEXT:   %4 = load { ptr }, ptr %0, align 8
@@ -122,54 +122,54 @@ func demo5(n int) Func {
 	return func(a, b int) int { return a + b + n }
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closureconv.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo1"(i64 1)
-// CHECK-NEXT:   %1 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %0, 1
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %0, 0
+// CHECK-NEXT:   %0 = call %main.Func @main.demo1(i64 1)
+// CHECK-NEXT:   %1 = extractvalue %main.Func %0, 1
+// CHECK-NEXT:   %2 = extractvalue %main.Func %0, 0
 // CHECK-NEXT:   %3 = call i64 %2(ptr %1, i64 99, i64 200)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %4 = call %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo2"()
-// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %4, 1
-// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %4, 0
+// CHECK-NEXT:   %4 = call %main.Func @main.demo2()
+// CHECK-NEXT:   %5 = extractvalue %main.Func %4, 1
+// CHECK-NEXT:   %6 = extractvalue %main.Func %4, 0
 // CHECK-NEXT:   %7 = call i64 %6(ptr %5, i64 100, i64 200)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %7)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %8 = call %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo3"()
-// CHECK-NEXT:   %9 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %8, 1
-// CHECK-NEXT:   %10 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %8, 0
+// CHECK-NEXT:   %8 = call %main.Func @main.demo3()
+// CHECK-NEXT:   %9 = extractvalue %main.Func %8, 1
+// CHECK-NEXT:   %10 = extractvalue %main.Func %8, 0
 // CHECK-NEXT:   %11 = call i64 %10(ptr %9, i64 100, i64 200)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %11)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %12 = call %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo4"()
-// CHECK-NEXT:   %13 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %12, 1
-// CHECK-NEXT:   %14 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %12, 0
+// CHECK-NEXT:   %12 = call %main.Func @main.demo4()
+// CHECK-NEXT:   %13 = extractvalue %main.Func %12, 1
+// CHECK-NEXT:   %14 = extractvalue %main.Func %12, 0
 // CHECK-NEXT:   %15 = call i64 %14(ptr %13, i64 100, i64 200)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %15)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %16 = call %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo5"(i64 1)
-// CHECK-NEXT:   %17 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %16, 1
-// CHECK-NEXT:   %18 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %16, 0
+// CHECK-NEXT:   %16 = call %main.Func @main.demo5(i64 1)
+// CHECK-NEXT:   %17 = extractvalue %main.Func %16, 1
+// CHECK-NEXT:   %18 = extractvalue %main.Func %16, 0
 // CHECK-NEXT:   %19 = call i64 %18(ptr %17, i64 99, i64 200)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %19)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %20 = call %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo5"(i64 1)
+// CHECK-NEXT:   %20 = call %main.Func @main.demo5(i64 1)
 // CHECK-NEXT:   %21 = alloca { ptr, ptr }, align 8
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/closureconv.Func" %20, ptr %21, align 8
+// CHECK-NEXT:   store %main.Func %20, ptr %21, align 8
 // CHECK-NEXT:   %22 = load { ptr, ptr }, ptr %21, align 8
 // CHECK-NEXT:   %23 = extractvalue { ptr, ptr } %22, 1
 // CHECK-NEXT:   %24 = extractvalue { ptr, ptr } %22, 0
 // CHECK-NEXT:   %25 = call i64 %24(ptr %23, i64 99, i64 200)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %25)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %26 = call %"{{.*}}/cl/_testrt/closureconv.Func" @"{{.*}}/cl/_testrt/closureconv.demo5"(i64 1)
-// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %26, 0
-// CHECK-NEXT:   %28 = insertvalue %"{{.*}}/cl/_testrt/closureconv.Func2" undef, ptr %27, 0
-// CHECK-NEXT:   %29 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func" %26, 1
-// CHECK-NEXT:   %30 = insertvalue %"{{.*}}/cl/_testrt/closureconv.Func2" %28, ptr %29, 1
-// CHECK-NEXT:   %31 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func2" %30, 1
-// CHECK-NEXT:   %32 = extractvalue %"{{.*}}/cl/_testrt/closureconv.Func2" %30, 0
+// CHECK-NEXT:   %26 = call %main.Func @main.demo5(i64 1)
+// CHECK-NEXT:   %27 = extractvalue %main.Func %26, 0
+// CHECK-NEXT:   %28 = insertvalue %main.Func2 undef, ptr %27, 0
+// CHECK-NEXT:   %29 = extractvalue %main.Func %26, 1
+// CHECK-NEXT:   %30 = insertvalue %main.Func2 %28, ptr %29, 1
+// CHECK-NEXT:   %31 = extractvalue %main.Func2 %30, 1
+// CHECK-NEXT:   %32 = extractvalue %main.Func2 %30, 0
 // CHECK-NEXT:   %33 = call i64 %32(ptr %31, i64 99, i64 200)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %33)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -199,22 +199,22 @@ func main() {
 	println(fn2(99, 200))
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closureconv.(*Call).add$bound"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*Call).add$bound"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %3 = load { ptr }, ptr %0, align 8
 // CHECK-NEXT:   %4 = extractvalue { ptr } %3, 0
-// CHECK-NEXT:   %5 = call i64 @"{{.*}}/cl/_testrt/closureconv.(*Call).add"(ptr %4, i64 %1, i64 %2)
+// CHECK-NEXT:   %5 = call i64 @"main.(*Call).add"(ptr %4, i64 %1, i64 %2)
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closureconv.add"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @__llgo_stub.main.add(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testrt/closureconv.add"(i64 %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @main.add(i64 %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closureconv.demo4$1"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.demo4$1"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testrt/closureconv.demo4$1"(i64 %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.demo4$1"(i64 %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }

--- a/cl/_testrt/closureiface/in.go
+++ b/cl/_testrt/closureiface/in.go
@@ -1,14 +1,14 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closureiface.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   store i64 200, ptr %0, align 8
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/closureiface.main$1", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %1, 1
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { ptr, ptr } %3, ptr %4, align 8
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr undef }, ptr %4, 1
@@ -49,7 +49,7 @@ package main
 // CHECK-NEXT: }
 func main() {
 	var m int = 200
-	// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closureiface.main$1"(ptr %0, i64 %1){{.*}} {
+	// CHECK-LABEL: define i64 @"main.main$1"(ptr %0, i64 %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
 	// CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0

--- a/cl/_testrt/complex/in.go
+++ b/cl/_testrt/complex/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/complex.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.PrintComplex"({ double, double } { double -5.000000e+00, double 1.000000e+01 })
 // CHECK: call { double, double } @"{{.*}}/runtime/internal/runtime.Complex128Div"({ double, double } { double 1.000000e+00, double 2.000000e+00 }, { double, double } { double 3.000000e+00, double 4.000000e+00 })
 // CHECK: call { double, double } @"{{.*}}/runtime/internal/runtime.Complex128Div"({ double, double } { double 1.000000e+00, double 2.000000e+00 }, { double, double } zeroinitializer)

--- a/cl/_testrt/concat/in.go
+++ b/cl/_testrt/concat/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/concat.concat"(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.concat(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   br label %_llgo_1
@@ -35,7 +35,7 @@ func concat(args ...string) (ret string) {
 	return
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/concat.info"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.info(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" zeroinitializer, %"{{.*}}/runtime/internal/runtime.String" %0)
 // CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 })
@@ -45,7 +45,7 @@ func info(s string) string {
 	return "" + s + "..."
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/concat.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 48)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %0, i64 0
@@ -57,7 +57,7 @@ func info(s string) string {
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %4, i64 3, 1
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %5, i64 3, 2
-// CHECK-NEXT:   %7 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/concat.concat"(%"{{.*}}/runtime/internal/runtime.Slice" %6)
+// CHECK-NEXT:   %7 = call %"{{.*}}/runtime/internal/runtime.String" @main.concat(%"{{.*}}/runtime/internal/runtime.Slice" %6)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %7)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void

--- a/cl/_testrt/constuptr/in.go
+++ b/cl/_testrt/constuptr/in.go
@@ -5,7 +5,7 @@ import (
 	"unsafe"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/constuptr.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr inttoptr (i64 100 to ptr))
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)

--- a/cl/_testrt/cstr/in.go
+++ b/cl/_testrt/cstr/in.go
@@ -11,7 +11,7 @@ func cstr(string) *int8
 //go:linkname printf C.printf
 func printf(format *int8, __llgo_va_list ...any)
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cstr.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void (ptr, ...) @printf(ptr @0)
 // CHECK-NEXT:   ret void

--- a/cl/_testrt/cvar/in.go
+++ b/cl/_testrt/cvar/in.go
@@ -18,7 +18,7 @@ var barY struct {
 	Arr [16]int8
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cvar.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = load { [16 x i8], [2 x ptr] }, ptr @_bar_x, align 8
 // CHECK-NEXT:   %1 = load { [16 x i8] }, ptr @_bar_y, align 1

--- a/cl/_testrt/eface/in.go
+++ b/cl/_testrt/eface/in.go
@@ -7,7 +7,7 @@ import (
 	"github.com/goplus/llgo/runtime/abi"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/eface.(*T).Invoke"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*T).Invoke"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 6 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -17,13 +17,13 @@ func (t *T) Invoke() {
 	println("invoke")
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/eface.dump"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
+// CHECK-LABEL: define void @main.dump(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/eface.eface", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.eface, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/eface.dumpTyp"(ptr %3, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer)
+// CHECK-NEXT:   call void @main.dumpTyp(ptr %3, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func dump(v any) {
@@ -31,7 +31,7 @@ func dump(v any) {
 	dumpTyp(e._type, "")
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/eface.dumpTyp"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
+// CHECK-LABEL: define void @main.dumpTyp(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %1)
 // CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/abi.(*Type).String"(ptr %0)
@@ -77,7 +77,7 @@ func dump(v any) {
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %0)
 // CHECK-NEXT:   %23 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 7 })
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/eface.dumpTyp"(ptr %22, %"{{.*}}/runtime/internal/runtime.String" %23)
+// CHECK-NEXT:   call void @main.dumpTyp(ptr %22, %"{{.*}}/runtime/internal/runtime.String" %23)
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -88,7 +88,7 @@ func dump(v any) {
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %0)
 // CHECK-NEXT:   %27 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 9 })
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/eface.dumpUncommon"(ptr %26, %"{{.*}}/runtime/internal/runtime.String" %27)
+// CHECK-NEXT:   call void @main.dumpUncommon(ptr %26, %"{{.*}}/runtime/internal/runtime.String" %27)
 // CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 10
 // CHECK-NEXT:   %29 = load ptr, ptr %28, align 8
 // CHECK-NEXT:   %30 = icmp ne ptr %29, null
@@ -102,7 +102,7 @@ func dump(v any) {
 // CHECK-NEXT:   %32 = load ptr, ptr %31, align 8
 // CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %32)
 // CHECK-NEXT:   %34 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 9 })
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/eface.dumpUncommon"(ptr %33, %"{{.*}}/runtime/internal/runtime.String" %34)
+// CHECK-NEXT:   call void @main.dumpUncommon(ptr %33, %"{{.*}}/runtime/internal/runtime.String" %34)
 // CHECK-NEXT:   br label %_llgo_4
 // CHECK-NEXT: }
 func dumpTyp(t *abi.Type, sep string) {
@@ -119,7 +119,7 @@ func dumpTyp(t *abi.Type, sep string) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/eface.dumpUncommon"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
+// CHECK-LABEL: define void @main.dumpUncommon(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %1)
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/runtime/abi.UncommonType", ptr %0, i32 0, i32 0
@@ -151,21 +151,21 @@ type eface struct {
 	data  unsafe.Pointer
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/eface.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 1)
 // CHECK: store i1 true, ptr {{%[0-9]+}}, align 1
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_bool, ptr undef }
-// CHECK: call void @"{{.*}}/cl/_testrt/eface.dump"
+// CHECK: call void @main.dump
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK: store i64 0, ptr {{%[0-9]+}}, align 8
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }
-// CHECK: call void @"{{.*}}/cl/_testrt/eface.dump"
+// CHECK: call void @main.dump
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 80)
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"[10]_llgo_int"
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"[]_llgo_int"
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"{{.*}}/cl/_testrt/eface.struct
-// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/eface.T"
+// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.T
 // CHECK: ret void
 func main() {
 	dump(true)
@@ -184,7 +184,7 @@ func main() {
 	dump(float64(0))
 	dump([10]int{})
 	dump(func() {})
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/eface.main$1"(){{.*}} {
+	// CHECK-LABEL: define void @"main.main$1"(){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   ret void
 	// CHECK-NEXT: }
@@ -200,8 +200,8 @@ func main() {
 	dump(t)
 }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/eface.main$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.main$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/eface.main$1"()
+// CHECK-NEXT:   tail call void @"main.main$1"()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/float2any/in.go
+++ b/cl/_testrt/float2any/in.go
@@ -18,7 +18,7 @@ type u64parts struct {
 	hi uint32
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/float2any.check32"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
+// CHECK-LABEL: define void @main.check32(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK: icmp eq ptr {{.*}}, @_llgo_float32
 // CHECK: load i32, ptr
 // CHECK: icmp ne i32 {{.*}}, 1078530011
@@ -34,7 +34,7 @@ func check32(v any) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/float2any.check64"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
+// CHECK-LABEL: define void @main.check64(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK: icmp eq ptr {{.*}}, @_llgo_float64
 // CHECK: load i32, ptr
 // CHECK: icmp ne i32 {{.*}}, 1405670641
@@ -53,7 +53,7 @@ func check64(v any) {
 	}
 }
 
-// CHECK-LABEL: define float @"{{.*}}/cl/_testrt/float2any.f32"(){{.*}} {
+// CHECK-LABEL: define float @main.f32(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret float 0x400921FB60000000
 // CHECK-NEXT: }
@@ -61,7 +61,7 @@ func f32() float32 {
 	return pi
 }
 
-// CHECK-LABEL: define double @"{{.*}}/cl/_testrt/float2any.f64"(){{.*}} {
+// CHECK-LABEL: define double @main.f64(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret double 0x400921FB53C8D4F1
 // CHECK-NEXT: }
@@ -69,18 +69,18 @@ func f64() float64 {
 	return pi
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/float2any.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call float @"{{.*}}/cl/_testrt/float2any.f32"()
+// CHECK-NEXT:   %0 = call float @main.f32()
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 4)
 // CHECK-NEXT:   store float %0, ptr %1, align 4
 // CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_float32, ptr undef }, ptr %1, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/float2any.check32"(%"{{.*}}/runtime/internal/runtime.eface" %2)
-// CHECK-NEXT:   %3 = call double @"{{.*}}/cl/_testrt/float2any.f64"()
+// CHECK-NEXT:   call void @main.check32(%"{{.*}}/runtime/internal/runtime.eface" %2)
+// CHECK-NEXT:   %3 = call double @main.f64()
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store double %3, ptr %4, align 8
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_float64, ptr undef }, ptr %4, 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/float2any.check64"(%"{{.*}}/runtime/internal/runtime.eface" %5)
+// CHECK-NEXT:   call void @main.check64(%"{{.*}}/runtime/internal/runtime.eface" %5)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testrt/fprintf/in.go
+++ b/cl/_testrt/fprintf/in.go
@@ -14,7 +14,7 @@ var stderr unsafe.Pointer
 //go:linkname fprintf C.fprintf
 func fprintf(fp unsafe.Pointer, format *int8, __llgo_va_list ...any)
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/fprintf.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = load ptr, ptr @__stderrp, align 8
 // CHECK-NEXT:   call void (ptr, ptr, ...) @fprintf(ptr %0, ptr @0, i64 100)

--- a/cl/_testrt/freevars/in.go
+++ b/cl/_testrt/freevars/in.go
@@ -1,20 +1,20 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/freevars.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/freevars.main$1"({ ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/freevars.main$2", ptr null })
+// CHECK-NEXT:   call void @"main.main$1"({ ptr, ptr } { ptr @"__llgo_stub.main.main$2", ptr null })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/freevars.main$1"({ ptr, ptr } %0){{.*}} {
+	// CHECK-LABEL: define void @"main.main$1"({ ptr, ptr } %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 	// CHECK-NEXT:   store { ptr, ptr } %0, ptr %1, align 8
 	// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 	// CHECK-NEXT:   %3 = getelementptr inbounds { ptr }, ptr %2, i32 0, i32 0
 	// CHECK-NEXT:   store ptr %1, ptr %3, align 8
-	// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/freevars.main$1$1", ptr undef }, ptr %2, 1
+	// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"main.main$1$1", ptr undef }, ptr %2, 1
 	// CHECK-NEXT:   %5 = extractvalue { ptr, ptr } %4, 1
 	// CHECK-NEXT:   %6 = extractvalue { ptr, ptr } %4, 0
 	// CHECK-NEXT:   call void %6(ptr %5, %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
@@ -22,7 +22,7 @@ func main() {
 	// CHECK-NEXT: }
 	func(resolve func(error)) {
 
-		// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/freevars.main$1$1"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+		// CHECK-LABEL: define void @"main.main$1$1"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
 		// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %1)
@@ -53,7 +53,7 @@ func main() {
 		// CHECK-NEXT:   ret void
 		// CHECK-NEXT: }
 
-		// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/freevars.main$2"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
+		// CHECK-LABEL: define void @"main.main$2"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   ret void
 		// CHECK-NEXT: }
@@ -68,8 +68,8 @@ func main() {
 	})
 }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/freevars.main$2"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.main$2"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/freevars.main$2"(%"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   tail call void @"main.main$2"(%"{{.*}}/runtime/internal/runtime.iface" %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/funcaddr/in.go
+++ b/cl/_testrt/funcaddr/in.go
@@ -10,7 +10,7 @@ import (
 //llgo:type C
 type Add func(int, int) int
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/funcaddr.add"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.add(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
@@ -19,14 +19,14 @@ func add(a, b int) int {
 	return a + b
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/funcaddr.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   store ptr @"{{.*}}/cl/_testrt/funcaddr.add", ptr %0, align 8
+// CHECK-NEXT:   store ptr @main.add, ptr %0, align 8
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   store ptr @"{{.*}}/cl/_testrt/funcaddr.main$1", ptr %1, align 8
+// CHECK-NEXT:   store ptr @"main.main$1", ptr %1, align 8
 // CHECK-NEXT:   %2 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %3 = icmp eq ptr @"{{.*}}/cl/_testrt/funcaddr.add", %2
+// CHECK-NEXT:   %3 = icmp eq ptr @main.add, %2
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %3)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %4 = load ptr, ptr %0, align 8
@@ -43,7 +43,7 @@ func add(a, b int) int {
 // CHECK-NEXT: }
 func main() {
 	var fn Add = add
-	// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/funcaddr.main$1"(i64 %0, i64 %1){{.*}} {
+	// CHECK-LABEL: define i64 @"main.main$1"(i64 %0, i64 %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = add i64 %0, %1
 	// CHECK-NEXT:   ret i64 %2

--- a/cl/_testrt/funcdecl/in.go
+++ b/cl/_testrt/funcdecl/in.go
@@ -9,10 +9,10 @@ import (
 // CHECK: @5 = private unnamed_addr constant [4 x i8] c"demo", align 1
 // CHECK: @6 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/funcdecl.check"({ ptr, ptr } %0){{.*}} {
+// CHECK-LABEL: define void @main.check({ ptr, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testrt/funcdecl.demo", ptr null }, ptr %1, align 8
+// CHECK-NEXT:   store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %1, align 8
 // CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %1, 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store { ptr, ptr } %0, ptr %3, align 8
@@ -48,10 +48,10 @@ import (
 // CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %12, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %15)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @"{{.*}}/cl/_testrt/funcdecl.demo")
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr @main.demo)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %16 = call ptr @"{{.*}}/cl/_testrt/funcdecl.closurePtr"(%"{{.*}}/runtime/internal/runtime.eface" %2)
-// CHECK-NEXT:   %17 = call ptr @"{{.*}}/cl/_testrt/funcdecl.closurePtr"(%"{{.*}}/runtime/internal/runtime.eface" %4)
+// CHECK-NEXT:   %16 = call ptr @main.closurePtr(%"{{.*}}/runtime/internal/runtime.eface" %2)
+// CHECK-NEXT:   %17 = call ptr @main.closurePtr(%"{{.*}}/runtime/internal/runtime.eface" %4)
 // CHECK-NEXT:   %18 = icmp eq ptr %16, %17
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %18)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -71,11 +71,11 @@ func check(fn func()) {
 	println(closurePtr(a) == closurePtr(b))
 }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/funcdecl.closurePtr"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
+// CHECK-LABEL: define ptr @main.closurePtr(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/funcdecl.rtype", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.rtype, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 0
 // CHECK-NEXT:   %5 = load ptr, ptr %4, align 8
@@ -94,20 +94,20 @@ type rtype struct {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/funcdecl.demo"(){{.*}} {
+// CHECK-LABEL: define void @main.demo(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/funcdecl.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/funcdecl.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/funcdecl.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -118,11 +118,11 @@ func demo() {
 	println("demo")
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/funcdecl.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 5 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/funcdecl.check"({ ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testrt/funcdecl.demo", ptr null })
+// CHECK-NEXT:   call void @main.check({ ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -131,8 +131,8 @@ func main() {
 	check(demo)
 }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/funcdecl.demo"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce void @__llgo_stub.main.demo(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/funcdecl.demo"()
+// CHECK-NEXT:   tail call void @main.demo()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/gblarray/in.go
+++ b/cl/_testrt/gblarray/in.go
@@ -6,13 +6,13 @@ import (
 	"github.com/goplus/llgo/runtime/abi"
 )
 
-// CHECK: @"{{.*}}/cl/_testrt/gblarray.sizeBasicTypes" = global [25 x i64] [i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 16], align 8
+// CHECK: @main.sizeBasicTypes = global [25 x i64] [i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 16], align 8
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/gblarray.Basic"(i64 %0){{.*}} {
+// CHECK-LABEL: define ptr @main.Basic(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp uge i64 %0, 25
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %1, {{.*}})
-// CHECK-NEXT:   %2 = getelementptr inbounds ptr, ptr @"{{.*}}/cl/_testrt/gblarray.basicTypes", i64 %0
+// CHECK-NEXT:   %2 = getelementptr inbounds ptr, ptr @main.basicTypes, i64 %0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   ret ptr %3
 // CHECK-NEXT: }
@@ -20,13 +20,13 @@ func Basic(kind abi.Kind) *abi.Type {
 	return basicTypes[kind]
 }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/gblarray.basicType"(i64 %0){{.*}} {
+// CHECK-LABEL: define ptr @main.basicType(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 72)
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = icmp uge i64 %0, 25
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %3, {{.*}})
-// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr @"{{.*}}/cl/_testrt/gblarray.sizeBasicTypes", i64 %0
+// CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr @main.sizeBasicTypes, i64 %0
 // CHECK-NEXT:   %5 = load i64, ptr %4, align 8
 // CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %1, i32 0, i32 2
 // CHECK-NEXT:   %7 = trunc i64 %0 to i32
@@ -45,16 +45,16 @@ func basicType(kind abi.Kind) *abi.Type {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/gblarray.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/gblarray.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/gblarray.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/abi.init"()
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/cl/_testrt/gblarray.basicType"(i64 24)
-// CHECK-NEXT:   store ptr %1, ptr getelementptr inbounds (ptr, ptr @"{{.*}}/cl/_testrt/gblarray.basicTypes", i64 24), align 8
+// CHECK-NEXT:   %1 = call ptr @main.basicType(i64 24)
+// CHECK-NEXT:   store ptr %1, ptr getelementptr inbounds (ptr, ptr @main.basicTypes, i64 24), align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -69,9 +69,9 @@ var (
 	}
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/gblarray.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/cl/_testrt/gblarray.Basic"(i64 24)
+// CHECK-NEXT:   %0 = call ptr @main.Basic(i64 24)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 6
 // CHECK-NEXT:   %2 = load i8, ptr %1, align 1
 // CHECK-NEXT:   %3 = zext i8 %2 to i64

--- a/cl/_testrt/gotypes/in.go
+++ b/cl/_testrt/gotypes/in.go
@@ -1,20 +1,20 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/gotypes.foo"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
+// CHECK-LABEL: define void @main.foo(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func foo(bar) {
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/gotypes.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/gotypes.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/gotypes.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -30,9 +30,9 @@ type bar interface {
 	g(c chan func())
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/gotypes.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/gotypes.foo"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   call void @main.foo(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testrt/hello/in.go
+++ b/cl/_testrt/hello/in.go
@@ -3,15 +3,15 @@ package main
 
 import "github.com/goplus/llgo/cl/_testrt/hello/libc"
 
-// CHECK: {{^}}@"{{.*}}/cl/_testrt/hello.format" = global [10 x i8] c"Hello %d\0A\00", align 1{{$}}
+// CHECK: {{^}}@main.format = global [10 x i8] c"Hello %d\0A\00", align 1{{$}}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/hello.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/hello.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/hello.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -19,10 +19,10 @@ import "github.com/goplus/llgo/cl/_testrt/hello/libc"
 // CHECK-NEXT: }
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/hello.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 @strlen(ptr @"{{.*}}/cl/_testrt/hello.format")
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}/cl/_testrt/hello.format", i32 %0)
+// CHECK-NEXT:   %0 = call i32 @strlen(ptr @main.format)
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i32 %0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testrt/index/in.go
+++ b/cl/_testrt/index/in.go
@@ -3,13 +3,13 @@ package main
 
 // CHECK: @0 = private unnamed_addr constant [6 x i8] c"123456", align 1
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/index.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/index.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/index.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -25,34 +25,34 @@ type N [2]int
 type T *N
 type S []int
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/index.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testrt/index.point", align 8
+// CHECK-NEXT:   %0 = alloca %main.point, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = alloca [3 x %"{{.*}}/cl/_testrt/index.point"], align 8
+// CHECK-NEXT:   %1 = alloca [3 x %main.point], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 48, i1 false)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %1, i64 0
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %2, i32 0, i32 1
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %1, i64 1
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %5, i32 0, i32 1
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %1, i64 2
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %8, i32 0, i32 0
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %8, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.point, ptr %1, i64 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.point, ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.point, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.point, ptr %1, i64 1
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.point, ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.point, ptr %5, i32 0, i32 1
+// CHECK-NEXT:   %8 = getelementptr inbounds %main.point, ptr %1, i64 2
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.point, ptr %8, i32 0, i32 0
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.point, ptr %8, i32 0, i32 1
 // CHECK-NEXT:   store i64 1, ptr %3, align 8
 // CHECK-NEXT:   store i64 2, ptr %4, align 8
 // CHECK-NEXT:   store i64 3, ptr %6, align 8
 // CHECK-NEXT:   store i64 4, ptr %7, align 8
 // CHECK-NEXT:   store i64 5, ptr %9, align 8
 // CHECK-NEXT:   store i64 6, ptr %10, align 8
-// CHECK-NEXT:   %11 = load [3 x %"{{.*}}/cl/_testrt/index.point"], ptr %1, align 8
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %1, i64 2
-// CHECK-NEXT:   %13 = load %"{{.*}}/cl/_testrt/index.point", ptr %12, align 8
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/index.point" %13, ptr %0, align 8
-// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %11 = load [3 x %main.point], ptr %1, align 8
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.point, ptr %1, i64 2
+// CHECK-NEXT:   %13 = load %main.point, ptr %12, align 8
+// CHECK-NEXT:   store %main.point %13, ptr %0, align 8
+// CHECK-NEXT:   %14 = getelementptr inbounds %main.point, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %15 = load i64, ptr %14, align 8
-// CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %16 = getelementptr inbounds %main.point, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %17 = load i64, ptr %16, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %15)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)

--- a/cl/_testrt/intgen/in.go
+++ b/cl/_testrt/intgen/in.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testrt/intgen.genInts"(i64 %0, { ptr, ptr } %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @main.genInts(i64 %0, { ptr, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.MakeSlice"(i64 %0, i64 %0, i64 4)
 // CHECK-NEXT:   %3 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %2, 1
@@ -42,14 +42,14 @@ func genInts(n int, gen func() c.Int) []c.Int {
 	return a
 }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/intgen.(*generator).next"(ptr %0){{.*}} {
+// CHECK-LABEL: define i32 @"main.(*generator).next"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/intgen.generator", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.generator, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load i32, ptr %1, align 4
 // CHECK-NEXT:   %3 = add i32 %2, 1
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/intgen.generator", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.generator, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i32 %3, ptr %4, align 4
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testrt/intgen.generator", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.generator, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %6 = load i32, ptr %5, align 4
 // CHECK-NEXT:   ret i32 %6
 // CHECK-NEXT: }
@@ -62,9 +62,9 @@ type generator struct {
 	val c.Int
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/intgen.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testrt/intgen.genInts"(i64 5, { ptr, ptr } { ptr @__llgo_stub.rand, ptr null })
+// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } { ptr @__llgo_stub.rand, ptr null })
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -92,8 +92,8 @@ type generator struct {
 // CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %15 = getelementptr inbounds { ptr }, ptr %14, i32 0, i32 0
 // CHECK-NEXT:   store ptr %13, ptr %15, align 8
-// CHECK-NEXT:   %16 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/intgen.main$1", ptr undef }, ptr %14, 1
-// CHECK-NEXT:   %17 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testrt/intgen.genInts"(i64 5, { ptr, ptr } %16)
+// CHECK-NEXT:   %16 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %14, 1
+// CHECK-NEXT:   %17 = call %"{{.*}}/runtime/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %16)
 // CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %17, 1
 // CHECK-NEXT:   br label %_llgo_4
 // CHECK-EMPTY:
@@ -117,13 +117,13 @@ type generator struct {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_4
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 4)
-// CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/cl/_testrt/intgen.generator", ptr %30, i32 0, i32 0
+// CHECK-NEXT:   %31 = getelementptr inbounds %main.generator, ptr %30, i32 0, i32 0
 // CHECK-NEXT:   store i32 1, ptr %31, align 4
 // CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %33 = getelementptr inbounds { ptr }, ptr %32, i32 0, i32 0
 // CHECK-NEXT:   store ptr %30, ptr %33, align 8
-// CHECK-NEXT:   %34 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/intgen.(*generator).next$bound", ptr undef }, ptr %32, 1
-// CHECK-NEXT:   %35 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testrt/intgen.genInts"(i64 5, { ptr, ptr } %34)
+// CHECK-NEXT:   %34 = insertvalue { ptr, ptr } { ptr @"main.(*generator).next$bound", ptr undef }, ptr %32, 1
+// CHECK-NEXT:   %35 = call %"{{.*}}/runtime/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %34)
 // CHECK-NEXT:   %36 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 1
 // CHECK-NEXT:   br label %_llgo_7
 // CHECK-EMPTY:
@@ -156,7 +156,7 @@ func main() {
 
 	initVal := c.Int(1)
 	ints := genInts(5, func() c.Int {
-		// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/intgen.main$1"(ptr %0){{.*}} {
+		// CHECK-LABEL: define i32 @"main.main$1"(ptr %0){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 		// CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
@@ -186,10 +186,10 @@ func main() {
 	// CHECK-NEXT: }
 }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/intgen.(*generator).next$bound"(ptr %0){{.*}} {
+// CHECK-LABEL: define i32 @"main.(*generator).next$bound"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
-// CHECK-NEXT:   %3 = call i32 @"{{.*}}/cl/_testrt/intgen.(*generator).next"(ptr %2)
+// CHECK-NEXT:   %3 = call i32 @"main.(*generator).next"(ptr %2)
 // CHECK-NEXT:   ret i32 %3
 // CHECK-NEXT: }

--- a/cl/_testrt/len/in.go
+++ b/cl/_testrt/len/in.go
@@ -8,25 +8,25 @@ type data struct {
 	a []int
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/len.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 56)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.String", ptr %1, align 8
 // CHECK-NEXT:   %3 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %2, 1
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %5 = load ptr, ptr %4, align 8
 // CHECK-NEXT:   %6 = call i64 @"{{.*}}/runtime/internal/runtime.ChanLen"(ptr %5)
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 2
 // CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
 // CHECK-NEXT:   %9 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %8)
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %0, i32 0, i32 3
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 3
 // CHECK-NEXT:   %11 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %10, align 8
 // CHECK-NEXT:   %12 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %11, 1
-// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %13 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %14 = load ptr, ptr %13, align 8
 // CHECK-NEXT:   %15 = call i64 @"{{.*}}/runtime/internal/runtime.ChanCap"(ptr %14)
-// CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %0, i32 0, i32 3
+// CHECK-NEXT:   %16 = getelementptr inbounds %main.data, ptr %0, i32 0, i32 3
 // CHECK-NEXT:   %17 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %16, align 8
 // CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %17, 2
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
@@ -42,16 +42,16 @@ type data struct {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %18)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 56)
-// CHECK-NEXT:   %20 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 0
-// CHECK-NEXT:   %21 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 1
+// CHECK-NEXT:   %20 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 0
+// CHECK-NEXT:   %21 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 1
 // CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 2)
-// CHECK-NEXT:   %23 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 2
+// CHECK-NEXT:   %23 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 2
 // CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 1)
 // CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr %25, align 8
 // CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %24, ptr %25)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %26, align 8
-// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 3
+// CHECK-NEXT:   %27 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 3
 // CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK-NEXT:   %29 = getelementptr inbounds i64, ptr %28, i64 0
 // CHECK-NEXT:   store i64 1, ptr %29, align 8
@@ -66,22 +66,22 @@ type data struct {
 // CHECK-NEXT:   store ptr %22, ptr %21, align 8
 // CHECK-NEXT:   store ptr %24, ptr %23, align 8
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %34, ptr %27, align 8
-// CHECK-NEXT:   %35 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 0
+// CHECK-NEXT:   %35 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 0
 // CHECK-NEXT:   %36 = load %"{{.*}}/runtime/internal/runtime.String", ptr %35, align 8
 // CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.String" %36, 1
-// CHECK-NEXT:   %38 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 1
+// CHECK-NEXT:   %38 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 1
 // CHECK-NEXT:   %39 = load ptr, ptr %38, align 8
 // CHECK-NEXT:   %40 = call i64 @"{{.*}}/runtime/internal/runtime.ChanLen"(ptr %39)
-// CHECK-NEXT:   %41 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 2
+// CHECK-NEXT:   %41 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 2
 // CHECK-NEXT:   %42 = load ptr, ptr %41, align 8
 // CHECK-NEXT:   %43 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %42)
-// CHECK-NEXT:   %44 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 3
+// CHECK-NEXT:   %44 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 3
 // CHECK-NEXT:   %45 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %44, align 8
 // CHECK-NEXT:   %46 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %45, 1
-// CHECK-NEXT:   %47 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 1
+// CHECK-NEXT:   %47 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 1
 // CHECK-NEXT:   %48 = load ptr, ptr %47, align 8
 // CHECK-NEXT:   %49 = call i64 @"{{.*}}/runtime/internal/runtime.ChanCap"(ptr %48)
-// CHECK-NEXT:   %50 = getelementptr inbounds %"{{.*}}/cl/_testrt/len.data", ptr %19, i32 0, i32 3
+// CHECK-NEXT:   %50 = getelementptr inbounds %main.data, ptr %19, i32 0, i32 3
 // CHECK-NEXT:   %51 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %50, align 8
 // CHECK-NEXT:   %52 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %51, 2
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %37)

--- a/cl/_testrt/linkname/in.go
+++ b/cl/_testrt/linkname/in.go
@@ -21,14 +21,14 @@ func setInfo(*m, string)
 //go:linkname info github.com/goplus/llgo/cl/_testrt/linkname/linktarget.m.info
 func info(m) string
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/linkname.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/linkname/linktarget.F"(ptr @0, ptr @1, ptr @2, ptr @3)
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/linkname/linktarget.F"(ptr @4, ptr @5, ptr @6, ptr @7)
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/linkname/linktarget.(*m).setInfo"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 5 })
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testrt/linkname.m", ptr %0, align 8
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/linkname/linktarget.m.info"(%"{{.*}}/cl/_testrt/linkname.m" %1)
+// CHECK-NEXT:   %1 = load %main.m, ptr %0, align 8
+// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/linkname/linktarget.m.info"(%main.m %1)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %2)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void

--- a/cl/_testrt/litdemo/in.go
+++ b/cl/_testrt/litdemo/in.go
@@ -3,21 +3,21 @@ package main
 
 var seed = 40
 
-// CHECK: @"{{.*}}/cl/_testrt/litdemo.seed" = global i64 40, align 8
+// CHECK: @main.seed = global i64 40, align 8
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/litdemo.add"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.add(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/litdemo.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/litdemo.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/litdemo.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -28,10 +28,10 @@ func add(x, y int) int {
 	return x + y
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/litdemo.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i64, ptr @"{{.*}}/cl/_testrt/litdemo.seed", align 8
-// CHECK-NEXT:   %1 = call i64 @"{{.*}}/cl/_testrt/litdemo.main$1"(i64 %0)
+// CHECK-NEXT:   %0 = load i64, ptr @main.seed, align 8
+// CHECK-NEXT:   %1 = call i64 @"main.main$1"(i64 %0)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %1)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
@@ -39,9 +39,9 @@ func add(x, y int) int {
 
 func main() {
 
-	// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/litdemo.main$1"(i64 %0){{.*}} {
+	// CHECK-LABEL: define i64 @"main.main$1"(i64 %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %1 = call i64 @"{{.*}}/cl/_testrt/litdemo.add"(i64 %0, i64 2)
+	// CHECK-NEXT:   %1 = call i64 @main.add(i64 %0, i64 2)
 	// CHECK-NEXT:   ret i64 %1
 	// CHECK-NEXT: }
 

--- a/cl/_testrt/makemap/in.go
+++ b/cl/_testrt/makemap/in.go
@@ -8,9 +8,9 @@ package main
 // CHECK: @22 = private unnamed_addr constant [2 x i8] c"go", align 1
 // CHECK: @23 = private unnamed_addr constant [7 x i8] c"bad key", align 1
 // CHECK: @24 = private unnamed_addr constant [7 x i8] c"bad len", align 1
-// CHECK: @32 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/makemap.N1", align 1
-// CHECK: @39 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testrt/makemap.K", align 1
-// CHECK: @42 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/makemap.K2", align 1
+// CHECK: @31 = private unnamed_addr constant [7 x i8] c"main.N1", align 1
+// CHECK: @33 = private unnamed_addr constant [6 x i8] c"main.K", align 1
+// CHECK: @40 = private unnamed_addr constant [7 x i8] c"main.K2", align 1
 
 func main() {
 	make1()
@@ -52,32 +52,32 @@ func make1() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/makemap.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/makemap.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/makemap.make1"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/makemap.make2"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/makemap.make3"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/makemap.make4"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/makemap.make5"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/makemap.make6"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/makemap.make7"()
+// CHECK-NEXT:   call void @main.make1()
+// CHECK-NEXT:   call void @main.make2()
+// CHECK-NEXT:   call void @main.make3()
+// CHECK-NEXT:   call void @main.make4()
+// CHECK-NEXT:   call void @main.make5()
+// CHECK-NEXT:   call void @main.make6()
+// CHECK-NEXT:   call void @main.make7()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make1"(){{.*}} {
+// CHECK-LABEL: define void @main.make1(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
@@ -255,7 +255,7 @@ func make1() {
 
 type N1 [1]int
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make2"(){{.*}} {
+// CHECK-LABEL: define void @main.make2(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
 // CHECK-NEXT:   %1 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %0)
@@ -286,7 +286,7 @@ type N1 [1]int
 // CHECK-NEXT:   %8 = load [1 x i64], ptr %6, align 8
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store [1 x i64] %8, ptr %9, align 8
-// CHECK-NEXT:   %10 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.N1", ptr undef }, ptr %9, 1
+// CHECK-NEXT:   %10 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %9, 1
 // CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %10, ptr %11, align 8
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %11)
@@ -298,7 +298,7 @@ type N1 [1]int
 // CHECK-NEXT:   %15 = load [1 x i64], ptr %13, align 8
 // CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store [1 x i64] %15, ptr %16, align 8
-// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.N1", ptr undef }, ptr %16, 1
+// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %16, 1
 // CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %17, ptr %18, align 8
 // CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %18)
@@ -310,7 +310,7 @@ type N1 [1]int
 // CHECK-NEXT:   %22 = load [1 x i64], ptr %20, align 8
 // CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store [1 x i64] %22, ptr %23, align 8
-// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.N1", ptr undef }, ptr %23, 1
+// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %23, 1
 // CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %24, ptr %25, align 8
 // CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %25)
@@ -322,7 +322,7 @@ type N1 [1]int
 // CHECK-NEXT:   %29 = load [1 x i64], ptr %27, align 8
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store [1 x i64] %29, ptr %30, align 8
-// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.N1", ptr undef }, ptr %30, 1
+// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.N1, ptr undef }, ptr %30, 1
 // CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %31, ptr %32, align 8
 // CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %32)
@@ -339,7 +339,7 @@ type N1 [1]int
 // CHECK-NEXT:   %37 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 1
 // CHECK-NEXT:   %38 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 2
 // CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 0
-// CHECK-NEXT:   %40 = icmp eq ptr %39, @"_llgo_{{.*}}/cl/_testrt/makemap.N1"
+// CHECK-NEXT:   %40 = icmp eq ptr %39, @_llgo_main.N1
 // CHECK-NEXT:   br i1 %40, label %_llgo_7, label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
@@ -404,60 +404,60 @@ type N struct {
 type K [1]N
 type K2 [1]*N
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make3"(){{.*}} {
+// CHECK-LABEL: define void @main.make3(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   %0 = alloca [1 x %main.N], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %0, i64 0
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.N, ptr %0, i64 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.N, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.N, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   store i8 1, ptr %2, align 1
 // CHECK-NEXT:   store i8 2, ptr %3, align 1
-// CHECK-NEXT:   %4 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %0, align 1
+// CHECK-NEXT:   %4 = load [1 x %main.N], ptr %0, align 1
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %4, ptr %5, align 1
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %5, 1
-// CHECK-NEXT:   %7 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   store [1 x %main.N] %4, ptr %5, align 1
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K, ptr undef }, ptr %5, 1
+// CHECK-NEXT:   %7 = alloca [1 x %main.N], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %7, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %7, i64 0
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %8, i32 0, i32 0
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %8, i32 0, i32 1
+// CHECK-NEXT:   %8 = getelementptr inbounds %main.N, ptr %7, i64 0
+// CHECK-NEXT:   %9 = getelementptr inbounds %main.N, ptr %8, i32 0, i32 0
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.N, ptr %8, i32 0, i32 1
 // CHECK-NEXT:   store i8 1, ptr %9, align 1
 // CHECK-NEXT:   store i8 2, ptr %10, align 1
-// CHECK-NEXT:   %11 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %7, align 1
+// CHECK-NEXT:   %11 = load [1 x %main.N], ptr %7, align 1
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %11, ptr %12, align 1
-// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %12, 1
+// CHECK-NEXT:   store [1 x %main.N] %11, ptr %12, align 1
+// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K, ptr undef }, ptr %12, 1
 // CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %6, %"{{.*}}/runtime/internal/runtime.eface" %13)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %14)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
-// CHECK-NEXT:   %16 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   %16 = alloca [1 x %main.N], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %16, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %16, i64 0
-// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %17, i32 0, i32 0
-// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %17, i32 0, i32 1
+// CHECK-NEXT:   %17 = getelementptr inbounds %main.N, ptr %16, i64 0
+// CHECK-NEXT:   %18 = getelementptr inbounds %main.N, ptr %17, i32 0, i32 0
+// CHECK-NEXT:   %19 = getelementptr inbounds %main.N, ptr %17, i32 0, i32 1
 // CHECK-NEXT:   store i8 1, ptr %18, align 1
 // CHECK-NEXT:   store i8 2, ptr %19, align 1
-// CHECK-NEXT:   %20 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %16, align 1
+// CHECK-NEXT:   %20 = load [1 x %main.N], ptr %16, align 1
 // CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %20, ptr %21, align 1
-// CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %21, 1
+// CHECK-NEXT:   store [1 x %main.N] %20, ptr %21, align 1
+// CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K, ptr undef }, ptr %21, 1
 // CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %22, ptr %23, align 8
 // CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %15, ptr %23)
 // CHECK-NEXT:   store i64 100, ptr %24, align 8
-// CHECK-NEXT:   %25 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   %25 = alloca [1 x %main.N], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %25, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %26 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %25, i64 0
-// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %26, i32 0, i32 0
-// CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %26, i32 0, i32 1
+// CHECK-NEXT:   %26 = getelementptr inbounds %main.N, ptr %25, i64 0
+// CHECK-NEXT:   %27 = getelementptr inbounds %main.N, ptr %26, i32 0, i32 0
+// CHECK-NEXT:   %28 = getelementptr inbounds %main.N, ptr %26, i32 0, i32 1
 // CHECK-NEXT:   store i8 3, ptr %27, align 1
 // CHECK-NEXT:   store i8 4, ptr %28, align 1
-// CHECK-NEXT:   %29 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %25, align 1
+// CHECK-NEXT:   %29 = load [1 x %main.N], ptr %25, align 1
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %29, ptr %30, align 1
-// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %30, 1
+// CHECK-NEXT:   store [1 x %main.N] %29, ptr %30, align 1
+// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K, ptr undef }, ptr %30, 1
 // CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %31, ptr %32, align 8
 // CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %15, ptr %32)
@@ -474,7 +474,7 @@ type K2 [1]*N
 // CHECK-NEXT:   %37 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 1
 // CHECK-NEXT:   %38 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 2
 // CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 0
-// CHECK-NEXT:   %40 = icmp eq ptr %39, @"_llgo_{{.*}}/cl/_testrt/makemap.K"
+// CHECK-NEXT:   %40 = icmp eq ptr %39, @_llgo_main.K
 // CHECK-NEXT:   br i1 %40, label %_llgo_7, label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
@@ -499,13 +499,13 @@ type K2 [1]*N
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 1
-// CHECK-NEXT:   %50 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %49, align 1
-// CHECK-NEXT:   %51 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   %50 = load [1 x %main.N], ptr %49, align 1
+// CHECK-NEXT:   %51 = alloca [1 x %main.N], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %51, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %50, ptr %51, align 1
-// CHECK-NEXT:   %52 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %51, i64 0
-// CHECK-NEXT:   %53 = load %"{{.*}}/cl/_testrt/makemap.N", ptr %52, align 1
-// CHECK-NEXT:   %54 = extractvalue %"{{.*}}/cl/_testrt/makemap.N" %53, 0
+// CHECK-NEXT:   store [1 x %main.N] %50, ptr %51, align 1
+// CHECK-NEXT:   %52 = getelementptr inbounds %main.N, ptr %51, i64 0
+// CHECK-NEXT:   %53 = load %main.N, ptr %52, align 1
+// CHECK-NEXT:   %54 = extractvalue %main.N %53, 0
 // CHECK-NEXT:   %55 = sext i8 %54 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %55)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -531,32 +531,32 @@ func make3() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make4"(){{.*}} {
+// CHECK-LABEL: define void @main.make4(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca [1 x ptr], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds ptr, ptr %0, i64 0
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.N, ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.N, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   store i8 1, ptr %3, align 1
 // CHECK-NEXT:   store i8 2, ptr %4, align 1
 // CHECK-NEXT:   store ptr %2, ptr %1, align 8
 // CHECK-NEXT:   %5 = load [1 x ptr], ptr %0, align 8
 // CHECK-NEXT:   %6 = extractvalue [1 x ptr] %5, 0
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %6, 1
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K2, ptr undef }, ptr %6, 1
 // CHECK-NEXT:   %8 = alloca [1 x ptr], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %8, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %9 = getelementptr inbounds ptr, ptr %8, i64 0
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %10, i32 0, i32 0
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %10, i32 0, i32 1
+// CHECK-NEXT:   %11 = getelementptr inbounds %main.N, ptr %10, i32 0, i32 0
+// CHECK-NEXT:   %12 = getelementptr inbounds %main.N, ptr %10, i32 0, i32 1
 // CHECK-NEXT:   store i8 1, ptr %11, align 1
 // CHECK-NEXT:   store i8 2, ptr %12, align 1
 // CHECK-NEXT:   store ptr %10, ptr %9, align 8
 // CHECK-NEXT:   %13 = load [1 x ptr], ptr %8, align 8
 // CHECK-NEXT:   %14 = extractvalue [1 x ptr] %13, 0
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %14, 1
+// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K2, ptr undef }, ptr %14, 1
 // CHECK-NEXT:   %16 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %7, %"{{.*}}/runtime/internal/runtime.eface" %15)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %16)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -565,14 +565,14 @@ func make3() {
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %19 = getelementptr inbounds ptr, ptr %18, i64 0
 // CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %21 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %20, i32 0, i32 0
-// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %20, i32 0, i32 1
+// CHECK-NEXT:   %21 = getelementptr inbounds %main.N, ptr %20, i32 0, i32 0
+// CHECK-NEXT:   %22 = getelementptr inbounds %main.N, ptr %20, i32 0, i32 1
 // CHECK-NEXT:   store i8 1, ptr %21, align 1
 // CHECK-NEXT:   store i8 2, ptr %22, align 1
 // CHECK-NEXT:   store ptr %20, ptr %19, align 8
 // CHECK-NEXT:   %23 = load [1 x ptr], ptr %18, align 8
 // CHECK-NEXT:   %24 = extractvalue [1 x ptr] %23, 0
-// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %24, 1
+// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K2, ptr undef }, ptr %24, 1
 // CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %25, ptr %26, align 8
 // CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %17, ptr %26)
@@ -581,14 +581,14 @@ func make3() {
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %28, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %29 = getelementptr inbounds ptr, ptr %28, i64 0
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %30, i32 0, i32 0
-// CHECK-NEXT:   %32 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %30, i32 0, i32 1
+// CHECK-NEXT:   %31 = getelementptr inbounds %main.N, ptr %30, i32 0, i32 0
+// CHECK-NEXT:   %32 = getelementptr inbounds %main.N, ptr %30, i32 0, i32 1
 // CHECK-NEXT:   store i8 3, ptr %31, align 1
 // CHECK-NEXT:   store i8 4, ptr %32, align 1
 // CHECK-NEXT:   store ptr %30, ptr %29, align 8
 // CHECK-NEXT:   %33 = load [1 x ptr], ptr %28, align 8
 // CHECK-NEXT:   %34 = extractvalue [1 x ptr] %33, 0
-// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %34, 1
+// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.K2, ptr undef }, ptr %34, 1
 // CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %35, ptr %36, align 8
 // CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %17, ptr %36)
@@ -605,7 +605,7 @@ func make3() {
 // CHECK-NEXT:   %41 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 1
 // CHECK-NEXT:   %42 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 2
 // CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %41, 0
-// CHECK-NEXT:   %44 = icmp eq ptr %43, @"_llgo_{{.*}}/cl/_testrt/makemap.K2"
+// CHECK-NEXT:   %44 = icmp eq ptr %43, @_llgo_main.K2
 // CHECK-NEXT:   br i1 %44, label %_llgo_7, label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
@@ -636,7 +636,7 @@ func make3() {
 // CHECK-NEXT:   store [1 x ptr] %54, ptr %55, align 8
 // CHECK-NEXT:   %56 = getelementptr inbounds ptr, ptr %55, i64 0
 // CHECK-NEXT:   %57 = load ptr, ptr %56, align 8
-// CHECK-NEXT:   %58 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %57, i32 0, i32 0
+// CHECK-NEXT:   %58 = getelementptr inbounds %main.N, ptr %57, i32 0, i32 0
 // CHECK-NEXT:   %59 = load i8, ptr %58, align 1
 // CHECK-NEXT:   %60 = sext i8 %59 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %60)
@@ -663,7 +663,7 @@ func make4() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make5"(){{.*}} {
+// CHECK-LABEL: define void @main.make5(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 0)
 // CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"chan _llgo_int", ptr undef }, ptr %0, 1
@@ -733,14 +733,14 @@ func make5() {
 
 type M map[int]string
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make6"(){{.*}} {
+// CHECK-LABEL: define void @main.make6(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"_llgo_{{.*}}/cl/_testrt/makemap.M", ptr %0, ptr %1)
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @_llgo_main.M, ptr %0, ptr %1)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"_llgo_{{.*}}/cl/_testrt/makemap.M", ptr %0)
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @_llgo_main.M, ptr %0)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
@@ -787,18 +787,18 @@ func make6() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make7"(){{.*}} {
+// CHECK-LABEL: define void @main.make7(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", i64 2)
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_main.N.7.0]_llgo_string", i64 2)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %1)
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %0, ptr %1)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %2, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 2, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %3)
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %0, ptr %3)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0)
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %0)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
@@ -818,7 +818,7 @@ func make6() {
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr %10, align 8
-// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %10)
+// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_main.N.7.0]_llgo_string", ptr %0, ptr %10)
 // CHECK-NEXT:   %12 = load %"{{.*}}/runtime/internal/runtime.String", ptr %11, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %12)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)

--- a/cl/_testrt/map/in.go
+++ b/cl/_testrt/map/in.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/map.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_int", i64 2)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)

--- a/cl/_testrt/mapclosure/in.go
+++ b/cl/_testrt/mapclosure/in.go
@@ -5,7 +5,7 @@ type Type interface {
 	String() string
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/mapclosure.demo"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @main.demo(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %0)
 // CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %0, 0
@@ -33,30 +33,30 @@ var (
 	list = []func(Type) string{demo}
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/mapclosure.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/mapclosure.typ", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.typ, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 5 }, ptr %1, align 8
-// CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testrt/mapclosure.op", align 8
+// CHECK-NEXT:   %2 = load ptr, ptr @main.op, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 4 }, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_string]_llgo_closure$vc5ZLfKV4flbpeFUtiJWFVJOxWgjZ8JlkoV1ZmTbVIQ", ptr %2, ptr %3)
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_string]_llgo_closure${{[-A-Za-z0-9_]+}}", ptr %2, ptr %3)
 // CHECK-NEXT:   %5 = load { ptr, ptr }, ptr %4, align 8
-// CHECK-NEXT:   %6 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr @"{{.*}}/cl/_testrt/mapclosure.list", align 8
+// CHECK-NEXT:   %6 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr @main.list, align 8
 // CHECK-NEXT:   %7 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 0
 // CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 1
 // CHECK-NEXT:   %9 = icmp uge i64 0, %8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %9, {{.*}})
 // CHECK-NEXT:   %10 = getelementptr inbounds { ptr, ptr }, ptr %7, i64 0
 // CHECK-NEXT:   %11 = load { ptr, ptr }, ptr %10, align 8
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*_llgo_github.com/goplus/llgo/cl/_testrt/mapclosure.typ")
+// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*_llgo_main.typ")
 // CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %12, 0
 // CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %13, ptr %0, 1
 // CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %5, 1
 // CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %5, 0
 // CHECK-NEXT:   %17 = call %"{{.*}}/runtime/internal/runtime.String" %16(ptr %15, %"{{.*}}/runtime/internal/runtime.iface" %14)
-// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*_llgo_github.com/goplus/llgo/cl/_testrt/mapclosure.typ")
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*_llgo_main.typ")
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %18, 0
 // CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %19, ptr %0, 1
 // CHECK-NEXT:   %21 = extractvalue { ptr, ptr } %11, 1
@@ -85,9 +85,9 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/mapclosure.(*typ).String"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"main.(*typ).String"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/mapclosure.typ", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.typ, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.String", ptr %1, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }
@@ -96,8 +96,8 @@ func (t *typ) String() string {
 	return t.s
 }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/mapclosure.demo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @__llgo_stub.main.demo(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/mapclosure.demo"(%"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @main.demo(%"{{.*}}/runtime/internal/runtime.iface" %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }

--- a/cl/_testrt/mask/in.go
+++ b/cl/_testrt/mask/in.go
@@ -1,43 +1,43 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/mask.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 @"{{.*}}/cl/_testrt/mask.mask"(i8 1)
+// CHECK-NEXT:   %0 = call i32 @main.mask(i8 1)
 // CHECK-NEXT:   %1 = sext i32 %0 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %1)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testrt/mask.mask_shl"(i64 127, i64 5)
+// CHECK-NEXT:   %2 = call i64 @main.mask_shl(i64 127, i64 5)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %2)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %3 = call i8 @"{{.*}}/cl/_testrt/mask.mask_shl8"(i8 127, i64 5)
+// CHECK-NEXT:   %3 = call i8 @main.mask_shl8(i8 127, i64 5)
 // CHECK-NEXT:   %4 = sext i8 %3 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %4)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %5 = call i8 @"{{.*}}/cl/_testrt/mask.mask_shl8u"(i8 127, i64 5)
+// CHECK-NEXT:   %5 = call i8 @main.mask_shl8u(i8 127, i64 5)
 // CHECK-NEXT:   %6 = zext i8 %5 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %6)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %7 = call i8 @"{{.*}}/cl/_testrt/mask.mask_shl8"(i8 127, i64 16)
+// CHECK-NEXT:   %7 = call i8 @main.mask_shl8(i8 127, i64 16)
 // CHECK-NEXT:   %8 = sext i8 %7 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %8)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %9 = call i8 @"{{.*}}/cl/_testrt/mask.mask_shl8u"(i8 127, i64 16)
+// CHECK-NEXT:   %9 = call i8 @main.mask_shl8u(i8 127, i64 16)
 // CHECK-NEXT:   %10 = zext i8 %9 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %10)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %11 = call i64 @"{{.*}}/cl/_testrt/mask.mask_shr"(i64 127, i64 5)
+// CHECK-NEXT:   %11 = call i64 @main.mask_shr(i64 127, i64 5)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %11)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %12 = call i8 @"{{.*}}/cl/_testrt/mask.mask_shr8"(i8 127, i64 5)
+// CHECK-NEXT:   %12 = call i8 @main.mask_shr8(i8 127, i64 5)
 // CHECK-NEXT:   %13 = sext i8 %12 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %13)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %14 = call i8 @"{{.*}}/cl/_testrt/mask.mask_shr8u"(i8 127, i64 5)
+// CHECK-NEXT:   %14 = call i8 @main.mask_shr8u(i8 127, i64 5)
 // CHECK-NEXT:   %15 = zext i8 %14 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 %15)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %16 = call i8 @"{{.*}}/cl/_testrt/mask.mask_shr8"(i8 127, i64 16)
+// CHECK-NEXT:   %16 = call i8 @main.mask_shr8(i8 127, i64 16)
 // CHECK-NEXT:   %17 = sext i8 %16 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %17)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -56,7 +56,7 @@ func main() {
 	println(mask_shr8(127, 16))
 }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/mask.mask"(i8 %0){{.*}} {
+// CHECK-LABEL: define i32 @main.mask(i8 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = sext i8 %0 to i32
 // CHECK-NEXT:   %2 = shl i32 %1, 31
@@ -68,7 +68,7 @@ func mask(x int8) int32 {
 	return int32(x) << 31 >> 31
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/mask.mask_shl"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.mask_shl(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp slt i64 %1, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -81,7 +81,7 @@ func mask_shl(x int, y int) int {
 	return x << y
 }
 
-// CHECK-LABEL: define i8 @"{{.*}}/cl/_testrt/mask.mask_shl8"(i8 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i8 @main.mask_shl8(i8 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp slt i64 %1, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -95,7 +95,7 @@ func mask_shl8(x int8, y int) int8 {
 	return x << y
 }
 
-// CHECK-LABEL: define i8 @"{{.*}}/cl/_testrt/mask.mask_shl8u"(i8 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i8 @main.mask_shl8u(i8 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp slt i64 %1, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -109,7 +109,7 @@ func mask_shl8u(x uint8, y int) uint8 {
 	return x << y
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/mask.mask_shr"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @main.mask_shr(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp slt i64 %1, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -122,7 +122,7 @@ func mask_shr(x int, y int) int {
 	return x >> y
 }
 
-// CHECK-LABEL: define i8 @"{{.*}}/cl/_testrt/mask.mask_shr8"(i8 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i8 @main.mask_shr8(i8 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp slt i64 %1, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -136,7 +136,7 @@ func mask_shr8(x int8, y int) int8 {
 	return x >> y
 }
 
-// CHECK-LABEL: define i8 @"{{.*}}/cl/_testrt/mask.mask_shr8u"(i8 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i8 @main.mask_shr8u(i8 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp slt i64 %1, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNegativeShift"(i1 %2)

--- a/cl/_testrt/methodthunk/in.go
+++ b/cl/_testrt/methodthunk/in.go
@@ -10,9 +10,9 @@ type outer struct {
 	inner
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/methodthunk.(*InnerInt).M"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*InnerInt).M"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/methodthunk.InnerInt", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.InnerInt, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load i64, ptr %1, align 8
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
@@ -22,10 +22,10 @@ type InnerInt struct {
 	X int
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/methodthunk.(*OuterInt).M"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*OuterInt).M"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/methodthunk.OuterInt", ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testrt/methodthunk.(*InnerInt).M"(ptr %1)
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.OuterInt, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = call i64 @"main.(*InnerInt).M"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 type OuterInt struct {
@@ -37,16 +37,16 @@ func (i *InnerInt) M() int {
 	return i.X
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/methodthunk.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/methodthunk.(*outer).M$thunk", ptr null }, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$31N-NdXOzvOy55m3NGAY_hdZ_NIdtCAe5V7uk7-a5HU", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.main.(*outer).M$thunk", ptr null }, ptr %0, align 8
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %0, 1
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/methodthunk.(*InnerInt).M$thunk", ptr null }, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$ygdobeQSbhO1hSbeWA66ORl_cNKHor-iD8MqRFtuWHg", ptr undef }, ptr %2, 1
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.main.(*InnerInt).M$thunk", ptr null }, ptr %2, align 8
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr undef }, ptr %2, 1
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %1, 0
-// CHECK-NEXT:   %5 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$31N-NdXOzvOy55m3NGAY_hdZ_NIdtCAe5V7uk7-a5HU", ptr %4)
+// CHECK-NEXT:   %5 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr %4)
 // CHECK-NEXT:   br i1 %5, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_8
@@ -79,7 +79,7 @@ func (i *InnerInt) M() int {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %14)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %16 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %3, 0
-// CHECK-NEXT:   %17 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$31N-NdXOzvOy55m3NGAY_hdZ_NIdtCAe5V7uk7-a5HU", ptr %16)
+// CHECK-NEXT:   %17 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure${{[-A-Za-z0-9_]+}}", ptr %16)
 // CHECK-NEXT:   br i1 %17, label %_llgo_6, label %_llgo_7
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5
@@ -115,21 +115,21 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/methodthunk.(*outer).M"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*outer).M"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func (m *outer) M() {}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/methodthunk.(*outer).M$thunk"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*outer).M$thunk"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/methodthunk.(*outer).M"(ptr %0)
+// CHECK-NEXT:   call void @"main.(*outer).M"(ptr %0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/methodthunk.(*outer).M$thunk"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.(*outer).M$thunk"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/methodthunk.(*outer).M$thunk"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.(*outer).M$thunk"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -139,14 +139,14 @@ func (m *outer) M() {}
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/methodthunk.(*InnerInt).M$thunk"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"main.(*InnerInt).M$thunk"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call i64 @"{{.*}}/cl/_testrt/methodthunk.(*InnerInt).M"(ptr %0)
+// CHECK-NEXT:   %1 = call i64 @"main.(*InnerInt).M"(ptr %0)
 // CHECK-NEXT:   ret i64 %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/methodthunk.(*InnerInt).M$thunk"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.(*InnerInt).M$thunk"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testrt/methodthunk.(*InnerInt).M$thunk"(ptr %1)
+// CHECK-NEXT:   %2 = tail call i64 @"main.(*InnerInt).M$thunk"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }

--- a/cl/_testrt/named/in.go
+++ b/cl/_testrt/named/in.go
@@ -22,89 +22,89 @@ type mspan struct {
 	check func(int) int
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/named.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 64)
 // CHECK-NEXT:   store ptr %1, ptr %0, align 8
 // CHECK-NEXT:   %2 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %2, i32 0, i32 4
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.mspan, ptr %2, i32 0, i32 4
 // CHECK-NEXT:   store i64 100, ptr %3, align 8
 // CHECK-NEXT:   %4 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 64)
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %4, i32 0, i32 0
+// CHECK-NEXT:   %6 = getelementptr inbounds %main.mspan, ptr %4, i32 0, i32 0
 // CHECK-NEXT:   store ptr %5, ptr %6, align 8
 // CHECK-NEXT:   %7 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %7, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %main.mspan, ptr %7, i32 0, i32 0
 // CHECK-NEXT:   %9 = load ptr, ptr %8, align 8
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %9, i32 0, i32 4
+// CHECK-NEXT:   %10 = getelementptr inbounds %main.mspan, ptr %9, i32 0, i32 4
 // CHECK-NEXT:   store i64 200, ptr %10, align 8
 // CHECK-NEXT:   %11 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %11, i32 0, i32 2
+// CHECK-NEXT:   %13 = getelementptr inbounds %main.mspan, ptr %11, i32 0, i32 2
 // CHECK-NEXT:   store ptr %12, ptr %13, align 8
 // CHECK-NEXT:   %14 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %14, i32 0, i32 2
+// CHECK-NEXT:   %15 = getelementptr inbounds %main.mspan, ptr %14, i32 0, i32 2
 // CHECK-NEXT:   %16 = load ptr, ptr %15, align 8
 // CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 64)
-// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mSpanList", ptr %16, i32 0, i32 1
+// CHECK-NEXT:   %18 = getelementptr inbounds %main.mSpanList, ptr %16, i32 0, i32 1
 // CHECK-NEXT:   store ptr %17, ptr %18, align 8
 // CHECK-NEXT:   %19 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %20 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %19, i32 0, i32 2
+// CHECK-NEXT:   %20 = getelementptr inbounds %main.mspan, ptr %19, i32 0, i32 2
 // CHECK-NEXT:   %21 = load ptr, ptr %20, align 8
-// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mSpanList", ptr %21, i32 0, i32 1
+// CHECK-NEXT:   %22 = getelementptr inbounds %main.mSpanList, ptr %21, i32 0, i32 1
 // CHECK-NEXT:   %23 = load ptr, ptr %22, align 8
-// CHECK-NEXT:   %24 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %23, i32 0, i32 4
+// CHECK-NEXT:   %24 = getelementptr inbounds %main.mspan, ptr %23, i32 0, i32 4
 // CHECK-NEXT:   store i64 300, ptr %24, align 8
 // CHECK-NEXT:   %25 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %26 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %25, i32 0, i32 3
-// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.minfo", ptr %26, i32 0, i32 1
+// CHECK-NEXT:   %26 = getelementptr inbounds %main.mspan, ptr %25, i32 0, i32 3
+// CHECK-NEXT:   %27 = getelementptr inbounds %main.minfo, ptr %26, i32 0, i32 1
 // CHECK-NEXT:   store i64 10, ptr %27, align 8
 // CHECK-NEXT:   %28 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %29 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %28, i32 0, i32 3
+// CHECK-NEXT:   %29 = getelementptr inbounds %main.mspan, ptr %28, i32 0, i32 3
 // CHECK-NEXT:   %30 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.minfo", ptr %29, i32 0, i32 0
+// CHECK-NEXT:   %31 = getelementptr inbounds %main.minfo, ptr %29, i32 0, i32 0
 // CHECK-NEXT:   store ptr %30, ptr %31, align 8
 // CHECK-NEXT:   %32 = load ptr, ptr %0, align 8
 // CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   %34 = getelementptr inbounds { ptr }, ptr %33, i32 0, i32 0
 // CHECK-NEXT:   store ptr %0, ptr %34, align 8
-// CHECK-NEXT:   %35 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/named.main$1", ptr undef }, ptr %33, 1
-// CHECK-NEXT:   %36 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %32, i32 0, i32 5
+// CHECK-NEXT:   %35 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %33, 1
+// CHECK-NEXT:   %36 = getelementptr inbounds %main.mspan, ptr %32, i32 0, i32 5
 // CHECK-NEXT:   store { ptr, ptr } %35, ptr %36, align 8
 // CHECK-NEXT:   %37 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %38 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %37, i32 0, i32 0
+// CHECK-NEXT:   %38 = getelementptr inbounds %main.mspan, ptr %37, i32 0, i32 0
 // CHECK-NEXT:   %39 = load ptr, ptr %38, align 8
-// CHECK-NEXT:   %40 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %39, i32 0, i32 4
+// CHECK-NEXT:   %40 = getelementptr inbounds %main.mspan, ptr %39, i32 0, i32 4
 // CHECK-NEXT:   %41 = load i64, ptr %40, align 8
 // CHECK-NEXT:   %42 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %43 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %42, i32 0, i32 2
+// CHECK-NEXT:   %43 = getelementptr inbounds %main.mspan, ptr %42, i32 0, i32 2
 // CHECK-NEXT:   %44 = load ptr, ptr %43, align 8
-// CHECK-NEXT:   %45 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mSpanList", ptr %44, i32 0, i32 1
+// CHECK-NEXT:   %45 = getelementptr inbounds %main.mSpanList, ptr %44, i32 0, i32 1
 // CHECK-NEXT:   %46 = load ptr, ptr %45, align 8
-// CHECK-NEXT:   %47 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %46, i32 0, i32 4
+// CHECK-NEXT:   %47 = getelementptr inbounds %main.mspan, ptr %46, i32 0, i32 4
 // CHECK-NEXT:   %48 = load i64, ptr %47, align 8
 // CHECK-NEXT:   %49 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %50 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %49, i32 0, i32 3
-// CHECK-NEXT:   %51 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.minfo", ptr %50, i32 0, i32 1
+// CHECK-NEXT:   %50 = getelementptr inbounds %main.mspan, ptr %49, i32 0, i32 3
+// CHECK-NEXT:   %51 = getelementptr inbounds %main.minfo, ptr %50, i32 0, i32 1
 // CHECK-NEXT:   %52 = load i64, ptr %51, align 8
 // CHECK-NEXT:   %53 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %54 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %53, i32 0, i32 3
-// CHECK-NEXT:   %55 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.minfo", ptr %54, i32 0, i32 0
+// CHECK-NEXT:   %54 = getelementptr inbounds %main.mspan, ptr %53, i32 0, i32 3
+// CHECK-NEXT:   %55 = getelementptr inbounds %main.minfo, ptr %54, i32 0, i32 0
 // CHECK-NEXT:   %56 = load ptr, ptr %55, align 8
-// CHECK-NEXT:   %57 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %56, i32 0, i32 4
+// CHECK-NEXT:   %57 = getelementptr inbounds %main.mspan, ptr %56, i32 0, i32 4
 // CHECK-NEXT:   %58 = load i64, ptr %57, align 8
 // CHECK-NEXT:   %59 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %60 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %59, i32 0, i32 5
+// CHECK-NEXT:   %60 = getelementptr inbounds %main.mspan, ptr %59, i32 0, i32 5
 // CHECK-NEXT:   %61 = load { ptr, ptr }, ptr %60, align 8
 // CHECK-NEXT:   %62 = extractvalue { ptr, ptr } %61, 1
 // CHECK-NEXT:   %63 = extractvalue { ptr, ptr } %61, 0
 // CHECK-NEXT:   %64 = call i64 %63(ptr %62, i64 -2)
 // CHECK-NEXT:   %65 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %66 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %65, i32 0, i32 3
-// CHECK-NEXT:   %67 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.minfo", ptr %66, i32 0, i32 0
+// CHECK-NEXT:   %66 = getelementptr inbounds %main.mspan, ptr %65, i32 0, i32 3
+// CHECK-NEXT:   %67 = getelementptr inbounds %main.minfo, ptr %66, i32 0, i32 0
 // CHECK-NEXT:   %68 = load ptr, ptr %67, align 8
-// CHECK-NEXT:   %69 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %68, i32 0, i32 5
+// CHECK-NEXT:   %69 = getelementptr inbounds %main.mspan, ptr %68, i32 0, i32 5
 // CHECK-NEXT:   %70 = load { ptr, ptr }, ptr %69, align 8
 // CHECK-NEXT:   %71 = extractvalue { ptr, ptr } %70, 1
 // CHECK-NEXT:   %72 = extractvalue { ptr, ptr } %70, 0
@@ -125,12 +125,12 @@ func main() {
 	m.check = func(n int) int {
 		return m.value * n
 	}
-	// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/named.main$1"(ptr %0, i64 %1){{.*}} {
+	// CHECK-LABEL: define i64 @"main.main$1"(ptr %0, i64 %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
 	// CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0
 	// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
-	// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testrt/named.mspan", ptr %4, i32 0, i32 4
+	// CHECK-NEXT:   %5 = getelementptr inbounds %main.mspan, ptr %4, i32 0, i32 4
 	// CHECK-NEXT:   %6 = load i64, ptr %5, align 8
 	// CHECK-NEXT:   %7 = mul i64 %6, %1
 	// CHECK-NEXT:   ret i64 %7

--- a/cl/_testrt/namedslice/in.go
+++ b/cl/_testrt/namedslice/in.go
@@ -3,12 +3,12 @@ package main
 
 type MyBytes []byte
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/namedslice.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %{{[0-9]+}} = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"__llgo.moduleZeroSizedAlloc$", i64 0, i64 0 }, ptr %{{[0-9]+}}, align 8
-// CHECK-NEXT:   %{{[0-9]+}} = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/namedslice.MyBytes", ptr undef }, ptr %{{[0-9]+}}, 1
-// CHECK: icmp eq ptr %{{[0-9]+}}, @"_llgo_github.com/goplus/llgo/cl/_testrt/namedslice.MyBytes"
+// CHECK-NEXT:   %{{[0-9]+}} = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.MyBytes, ptr undef }, ptr %{{[0-9]+}}, 1
+// CHECK: icmp eq ptr %{{[0-9]+}}, @_llgo_main.MyBytes
 // CHECK: call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %{{[0-9]+}})
 // CHECK: }
 func main() {

--- a/cl/_testrt/panic/in.go
+++ b/cl/_testrt/panic/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/panic.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 13 }, ptr %0, align 8

--- a/cl/_testrt/qsort/in.go
+++ b/cl/_testrt/qsort/in.go
@@ -10,7 +10,7 @@ import (
 //go:linkname qsort C.qsort
 func qsort(base c.Pointer, count, elem uintptr, compar func(a, b c.Pointer) c.Int)
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsort.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
 // CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -24,7 +24,7 @@ func qsort(base c.Pointer, count, elem uintptr, compar func(a, b c.Pointer) c.In
 // CHECK-NEXT:   store i64 2, ptr %4, align 8
 // CHECK-NEXT:   store i64 7, ptr %5, align 8
 // CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %0, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %6, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsort.main$1")
+// CHECK-NEXT:   call void @qsort(ptr %6, i64 5, i64 8, ptr @"main.main$1")
 // CHECK-NEXT:   %7 = load [5 x i64], ptr %0, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -52,7 +52,7 @@ func main() {
 	qsort(c.Pointer(&a[0]), 5, unsafe.Sizeof(0), func(a, b c.Pointer) c.Int {
 		return c.Int(*(*int)(a) - *(*int)(b))
 	})
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsort.main$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.main$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8

--- a/cl/_testrt/qsortfn/in.go
+++ b/cl/_testrt/qsortfn/in.go
@@ -8,18 +8,18 @@ import (
 	q "github.com/goplus/llgo/cl/_testrt/qsortfn/qsort"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort1a"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort1b"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort2a"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort2b"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort3a"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort3b"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort4a"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort4b"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort5a"()
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/qsortfn.sort5b"()
+// CHECK-NEXT:   call void @main.sort1a()
+// CHECK-NEXT:   call void @main.sort1b()
+// CHECK-NEXT:   call void @main.sort2a()
+// CHECK-NEXT:   call void @main.sort2b()
+// CHECK-NEXT:   call void @main.sort3a()
+// CHECK-NEXT:   call void @main.sort3b()
+// CHECK-NEXT:   call void @main.sort4a()
+// CHECK-NEXT:   call void @main.sort4b()
+// CHECK-NEXT:   call void @main.sort5a()
+// CHECK-NEXT:   call void @main.sort5b()
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {
@@ -35,7 +35,7 @@ func main() {
 	sort5b()
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort1a"(){{.*}} {
+// CHECK-LABEL: define void @main.sort1a(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @0)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -50,7 +50,7 @@ func main() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort1a$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort1a$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -76,7 +76,7 @@ func main() {
 func sort1a() {
 	c.Printf(c.Str("Comp => Comp\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort1a$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort1a$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -93,7 +93,7 @@ func sort1a() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort1b"(){{.*}} {
+// CHECK-LABEL: define void @main.sort1b(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @2)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -108,7 +108,7 @@ func sort1a() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort1b$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort1b$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -134,7 +134,7 @@ func sort1a() {
 func sort1b() {
 	c.Printf(c.Str("fn => Comp\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort1b$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort1b$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -151,7 +151,7 @@ func sort1b() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort2a"(){{.*}} {
+// CHECK-LABEL: define void @main.sort2a(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @4)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -166,7 +166,7 @@ func sort1b() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort2a$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort2a$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -192,7 +192,7 @@ func sort1b() {
 func sort2a() {
 	c.Printf(c.Str("Comp => fn\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort2a$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort2a$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -209,7 +209,7 @@ func sort2a() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort2b"(){{.*}} {
+// CHECK-LABEL: define void @main.sort2b(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @6)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -224,7 +224,7 @@ func sort2a() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort2b$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort2b$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -250,7 +250,7 @@ func sort2a() {
 func sort2b() {
 	c.Printf(c.Str("fn => fn\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort2b$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort2b$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -267,7 +267,7 @@ func sort2b() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort3a"(){{.*}} {
+// CHECK-LABEL: define void @main.sort3a(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @8)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -282,7 +282,7 @@ func sort2b() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort3a$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort3a$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -308,7 +308,7 @@ func sort2b() {
 func sort3a() {
 	c.Printf(c.Str("qsort.Comp => qsort.Comp\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort3a$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort3a$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -325,7 +325,7 @@ func sort3a() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort3b"(){{.*}} {
+// CHECK-LABEL: define void @main.sort3b(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @10)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -340,7 +340,7 @@ func sort3a() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort3b$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort3b$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -366,7 +366,7 @@ func sort3a() {
 func sort3b() {
 	c.Printf(c.Str("fn => qsort.Comp\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort3b$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort3b$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -383,7 +383,7 @@ func sort3b() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort4a"(){{.*}} {
+// CHECK-LABEL: define void @main.sort4a(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @12)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -398,7 +398,7 @@ func sort3b() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort4a$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort4a$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -424,7 +424,7 @@ func sort3b() {
 func sort4a() {
 	c.Printf(c.Str("qsort.Comp => fn\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort4a$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort4a$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -441,7 +441,7 @@ func sort4a() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort4b"(){{.*}} {
+// CHECK-LABEL: define void @main.sort4b(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @14)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -456,7 +456,7 @@ func sort4a() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort4b$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort4b$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -482,7 +482,7 @@ func sort4a() {
 func sort4b() {
 	c.Printf(c.Str("Comp => qsort.fn\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort4b$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort4b$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -499,7 +499,7 @@ func sort4b() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort5a"(){{.*}} {
+// CHECK-LABEL: define void @main.sort5a(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @16)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -514,7 +514,7 @@ func sort4b() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort5a$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort5a$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -540,7 +540,7 @@ func sort4b() {
 func sort5a() {
 	c.Printf(c.Str("qsort.Comp => Comp()\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort5a$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort5a$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8
@@ -557,7 +557,7 @@ func sort5a() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/qsortfn.sort5b"(){{.*}} {
+// CHECK-LABEL: define void @main.sort5b(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @18)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 40)
@@ -572,7 +572,7 @@ func sort5a() {
 // CHECK-NEXT:   store i64 2, ptr %5, align 8
 // CHECK-NEXT:   store i64 7, ptr %6, align 8
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"{{.*}}/cl/_testrt/qsortfn.sort5b$1")
+// CHECK-NEXT:   call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort5b$1")
 // CHECK-NEXT:   %8 = load [5 x i64], ptr %1, align 8
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -598,7 +598,7 @@ func sort5a() {
 func sort5b() {
 	c.Printf(c.Str("Comp => qsort.Comp()\n"))
 	a := [...]int{100, 8, 23, 2, 7}
-	// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/qsortfn.sort5b$1"(ptr %0, ptr %1){{.*}} {
+	// CHECK-LABEL: define i32 @"main.sort5b$1"(ptr %0, ptr %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
 	// CHECK-NEXT:   %3 = load i64, ptr %1, align 8

--- a/cl/_testrt/result/in.go
+++ b/cl/_testrt/result/in.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/result.add$1"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"main.add$1"(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
@@ -16,12 +16,12 @@ func add() func(int, int) int {
 	}
 }
 
-// CHECK-LABEL: define { { ptr, ptr }, i64 } @"{{.*}}/cl/_testrt/result.add2"(){{.*}} {
+// CHECK-LABEL: define { { ptr, ptr }, i64 } @main.add2(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret { { ptr, ptr }, i64 } { { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/result.add2$1", ptr null }, i64 1 }
+// CHECK-NEXT:   ret { { ptr, ptr }, i64 } { { ptr, ptr } { ptr @"__llgo_stub.main.add2$1", ptr null }, i64 1 }
 // CHECK-NEXT: }
 func add2() (func(int, int) int, int) {
-	// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/result.add2$1"(i64 %0, i64 %1){{.*}} {
+	// CHECK-LABEL: define i64 @"main.add2$1"(i64 %0, i64 %1){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %2 = add i64 %0, %1
 	// CHECK-NEXT:   ret i64 %2
@@ -31,22 +31,22 @@ func add2() (func(int, int) int, int) {
 	}, 1
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/result.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call { ptr, ptr } @"{{.*}}/cl/_testrt/result.main$1"()
+// CHECK-NEXT:   %0 = call { ptr, ptr } @"main.main$1"()
 // CHECK-NEXT:   %1 = extractvalue { ptr, ptr } %0, 1
 // CHECK-NEXT:   %2 = extractvalue { ptr, ptr } %0, 0
 // CHECK-NEXT:   %3 = call i64 %2(ptr %1, i64 100, i64 200)
 // CHECK-NEXT:   %4 = call i32 (ptr, ...) @printf(ptr @0, i64 %3)
-// CHECK-NEXT:   %5 = call { ptr, ptr } @"{{.*}}/cl/_testrt/result.add"()
+// CHECK-NEXT:   %5 = call { ptr, ptr } @main.add()
 // CHECK-NEXT:   %6 = extractvalue { ptr, ptr } %5, 1
 // CHECK-NEXT:   %7 = extractvalue { ptr, ptr } %5, 0
 // CHECK-NEXT:   %8 = call i64 %7(ptr %6, i64 100, i64 200)
 // CHECK-NEXT:   %9 = call i32 (ptr, ...) @printf(ptr @1, i64 %8)
-// CHECK-NEXT:   %10 = call { { ptr, ptr }, i64 } @"{{.*}}/cl/_testrt/result.add2"()
+// CHECK-NEXT:   %10 = call { { ptr, ptr }, i64 } @main.add2()
 // CHECK-NEXT:   %11 = extractvalue { { ptr, ptr }, i64 } %10, 0
 // CHECK-NEXT:   %12 = extractvalue { { ptr, ptr }, i64 } %10, 1
-// CHECK-NEXT:   %13 = call { ptr, ptr } @"{{.*}}/cl/_testrt/result.add"()
+// CHECK-NEXT:   %13 = call { ptr, ptr } @main.add()
 // CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
 // CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
 // CHECK-NEXT:   %16 = call i64 %15(ptr %14, i64 100, i64 200)
@@ -54,12 +54,12 @@ func add2() (func(int, int) int, int) {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {
-	// CHECK-LABEL: define { ptr, ptr } @"{{.*}}/cl/_testrt/result.main$1"(){{.*}} {
+	// CHECK-LABEL: define { ptr, ptr } @"main.main$1"(){{.*}} {
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   ret { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/result.main$1$1", ptr null }
+	// CHECK-NEXT:   ret { ptr, ptr } { ptr @"__llgo_stub.main.main$1$1", ptr null }
 	// CHECK-NEXT: }
 	fn := func() func(int, int) int {
-		// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/result.main$1$1"(i64 %0, i64 %1){{.*}} {
+		// CHECK-LABEL: define i64 @"main.main$1$1"(i64 %0, i64 %1){{.*}} {
 		// CHECK-NEXT: _llgo_0:
 		// CHECK-NEXT:   %2 = add i64 %0, %1
 		// CHECK-NEXT:   ret i64 %2
@@ -74,20 +74,20 @@ func main() {
 	c.Printf(c.Str("%d %d\n"), add()(100, 200), n)
 }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/result.add$1"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.add$1"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testrt/result.add$1"(i64 %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.add$1"(i64 %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/result.add2$1"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.add2$1"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testrt/result.add2$1"(i64 %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.add2$1"(i64 %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/result.main$1$1"(ptr %0, i64 %1, i64 %2){{.*}} {
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.main.main$1$1"(ptr %0, i64 %1, i64 %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %3 = tail call i64 @"{{.*}}/cl/_testrt/result.main$1$1"(i64 %1, i64 %2)
+// CHECK-NEXT:   %3 = tail call i64 @"main.main$1$1"(i64 %1, i64 %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }

--- a/cl/_testrt/slice2array/in.go
+++ b/cl/_testrt/slice2array/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/slice2array.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 4)
 // CHECK-NEXT:   %1 = getelementptr inbounds i8, ptr %0, i64 0

--- a/cl/_testrt/slicelen/in.go
+++ b/cl/_testrt/slicelen/in.go
@@ -20,20 +20,20 @@ func main() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/slicelen.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/slicelen.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/slicelen.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/slicelen.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 30 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 46 })

--- a/cl/_testrt/stacksave/in.go
+++ b/cl/_testrt/stacksave/in.go
@@ -9,7 +9,7 @@ import (
 //go:linkname getsp llgo.stackSave
 func getsp() unsafe.Pointer
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/stacksave.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @llvm.stacksave.p0()
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %0)

--- a/cl/_testrt/strlen/in.go
+++ b/cl/_testrt/strlen/in.go
@@ -12,10 +12,10 @@ func strlen(str *int8) C.int
 
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/strlen.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i32 @strlen(ptr @"{{.*}}/cl/_testrt/strlen.format")
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}/cl/_testrt/strlen.format", i32 %0)
+// CHECK-NEXT:   %0 = call i32 @strlen(ptr @main.format)
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i32 %0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testrt/struct/in.go
+++ b/cl/_testrt/struct/in.go
@@ -6,21 +6,21 @@ import _ "unsafe"
 
 // CHECK-DAG: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/struct.Foo", align 1{{$}}
 // CHECK-DAG: {{^}}@1 = private unnamed_addr constant [5 x i8] c"Print", align 1{{$}}
-// CHECK-DAG: @"{{.*}}/cl/_testrt/struct.format" = global [10 x i8] c"Hello %d\0A\00", align 1
+// CHECK-DAG: @main.format = global [10 x i8] c"Hello %d\0A\00", align 1
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %0){{.*}} {
+// CHECK-LABEL: define void @main.Foo.Print(%main.Foo %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/struct.Foo", align 8
+// CHECK-NEXT:   %1 = alloca %main.Foo, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/struct.Foo" %0, ptr %1, align 4
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/struct.Foo", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   store %main.Foo %0, ptr %1, align 4
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Foo, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load i1, ptr %2, align 1
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/struct.Foo", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.Foo, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %5 = load i32, ptr %4, align 4
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}/cl/_testrt/struct.format", i32 %5)
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i32 %5)
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -48,27 +48,27 @@ func main() {
 	foo.Print()
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.(*Foo).Print"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"main.(*Foo).Print"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 44 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 5 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/struct.Foo", ptr %0, align 4
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %2)
+// CHECK-NEXT:   %2 = load %main.Foo, ptr %0, align 4
+// CHECK-NEXT:   call void @main.Foo.Print(%main.Foo %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/struct._Cgo_ptr"(ptr %0){{.*}} {
+// CHECK-LABEL: define ptr @main._Cgo_ptr(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret ptr %0
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/struct.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/struct.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   call void @syscall.init()
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
@@ -76,15 +76,15 @@ func main() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testrt/struct.Foo", align 8
+// CHECK-NEXT:   %0 = alloca %main.Foo, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/struct.Foo", ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/struct.Foo", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.Foo, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.Foo, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i32 100, ptr %1, align 4
 // CHECK-NEXT:   store i1 true, ptr %2, align 1
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testrt/struct.Foo", ptr %0, align 4
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %3)
+// CHECK-NEXT:   %3 = load %main.Foo, ptr %0, align 4
+// CHECK-NEXT:   call void @main.Foo.Print(%main.Foo %3)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/structsize/in.go
+++ b/cl/_testrt/structsize/in.go
@@ -15,7 +15,7 @@ type Foo struct {
 	E [8]int8
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/structsize.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @0, i64 14)
 // CHECK-NEXT:   ret void

--- a/cl/_testrt/sum/in.go
+++ b/cl/_testrt/sum/in.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/sum.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
 // CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -19,7 +19,7 @@ import (
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %5, i64 4, 1
 // CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, i64 4, 2
-// CHECK-NEXT:   %8 = call i64 @"{{.*}}/cl/_testrt/sum.sum"(%"{{.*}}/runtime/internal/runtime.Slice" %7)
+// CHECK-NEXT:   %8 = call i64 @main.sum(%"{{.*}}/runtime/internal/runtime.Slice" %7)
 // CHECK-NEXT:   %9 = call i32 (ptr, ...) @printf(ptr @0, i64 %8)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -27,7 +27,7 @@ func main() {
 	c.Printf(c.Str("Hello %d\n"), sum(1, 2, 3, 4))
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/sum.sum"(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
+// CHECK-LABEL: define i64 @main.sum(%"{{.*}}/runtime/internal/runtime.Slice" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   br label %_llgo_1

--- a/cl/_testrt/tpabi/in.go
+++ b/cl/_testrt/tpabi/in.go
@@ -4,17 +4,17 @@ package main
 import "github.com/goplus/lib/c"
 
 // CHECK: @0 = private unnamed_addr constant [1 x i8] c"a", align 1
+// CHECK: @1 = private unnamed_addr constant [18 x i8] c"main.T[string,int]", align 1
 // CHECK: @5 = private unnamed_addr constant [4 x i8] c"Info", align 1
-// CHECK: @10 = private unnamed_addr constant [54 x i8] c"{{.*}}/cl/_testrt/tpabi.T[string, int]", align 1
 // CHECK: @11 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpabi.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/tpabi.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/tpabi.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -45,34 +45,34 @@ func (t *K[N]) Advance(n int) *K[N] {
 	return nil
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpabi.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testrt/tpabi.T[string,int]", align 8
+// CHECK-NEXT:   %0 = alloca %"main.T[string,int]", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 24, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %1 = getelementptr inbounds %"main.T[string,int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.T[string,int]", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 1 }, ptr %1, align 8
 // CHECK-NEXT:   store i64 1, ptr %2, align 8
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, align 8
+// CHECK-NEXT:   %3 = load %"main.T[string,int]", ptr %0, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/tpabi.T[string,int]" %3, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr undef }, ptr %4, 1
+// CHECK-NEXT:   store %"main.T[string,int]" %3, ptr %4, align 8
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_main.T[string,int]", ptr undef }, ptr %4, 1
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %5, 0
-// CHECK-NEXT:   %7 = icmp eq ptr %6, @"_llgo_{{.*}}/cl/_testrt/tpabi.T[string,int]"
+// CHECK-NEXT:   %7 = icmp eq ptr %6, @"_llgo_main.T[string,int]"
 // CHECK-NEXT:   br i1 %7, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %5, 1
-// CHECK-NEXT:   %9 = load %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %8, align 8
-// CHECK-NEXT:   %10 = extractvalue %"{{.*}}/cl/_testrt/tpabi.T[string,int]" %9, 0
+// CHECK-NEXT:   %9 = load %"main.T[string,int]", ptr %8, align 8
+// CHECK-NEXT:   %10 = extractvalue %"main.T[string,int]" %9, 0
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %10)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %11, i32 0, i32 0
-// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %11, i32 0, i32 1
+// CHECK-NEXT:   %12 = getelementptr inbounds %"main.T[string,int]", ptr %11, i32 0, i32 0
+// CHECK-NEXT:   %13 = getelementptr inbounds %"main.T[string,int]", ptr %11, i32 0, i32 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 5 }, ptr %12, align 8
 // CHECK-NEXT:   store i64 100, ptr %13, align 8
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", ptr @"*_llgo_{{.*}}/cl/_testrt/tpabi.T[string,int]")
+// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", ptr @"*_llgo_main.T[string,int]")
 // CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %14, 0
 // CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %15, ptr %11, 1
 // CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %16)
@@ -117,14 +117,14 @@ func main() {
 	println(k.Advance(1))
 }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpabi.T[string,int].Info"(%"{{.*}}/cl/_testrt/tpabi.T[string,int]" %0){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.T[string,int].Info"(%"main.T[string,int]" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/tpabi.T[string,int]", align 8
+// CHECK-NEXT:   %1 = alloca %"main.T[string,int]", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 24, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/tpabi.T[string,int]" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %"main.T[string,int]" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.T[string,int]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.String", ptr %2, align 8
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %4 = getelementptr inbounds %"main.T[string,int]", ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %5 = load i64, ptr %4, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %3)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -133,11 +133,11 @@ func main() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpabi.(*T[string,int]).Demo"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.(*T[string,int]).Demo"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %"main.T[string,int]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.String", ptr %1, align 8
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"main.T[string,int]", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %4 = load i64, ptr %3, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %2)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -146,24 +146,24 @@ func main() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpabi.(*T[string,int]).Info"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.(*T[string,int]).Info"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @10, i64 54 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, align 8
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/tpabi.T[string,int].Info"(%"{{.*}}/cl/_testrt/tpabi.T[string,int]" %2)
+// CHECK-NEXT:   %2 = load %"main.T[string,int]", ptr %0, align 8
+// CHECK-NEXT:   call void @"main.T[string,int].Info"(%"main.T[string,int]" %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/tpabi.(*T[string,int]).Demo"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.(*T[string,int]).Demo"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/tpabi.(*T[string,int]).Demo"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.(*T[string,int]).Demo"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/tpabi.(*T[string,int]).Info"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.(*T[string,int]).Info"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/tpabi.(*T[string,int]).Info"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.(*T[string,int]).Info"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -173,9 +173,9 @@ func main() {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/tpabi.T[string,int].Info"(ptr %0, %"{{.*}}/cl/_testrt/tpabi.T[string,int]" %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.T[string,int].Info"(ptr %0, %"main.T[string,int]" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/tpabi.T[string,int].Info"(%"{{.*}}/cl/_testrt/tpabi.T[string,int]" %1)
+// CHECK-NEXT:   tail call void @"main.T[string,int].Info"(%"main.T[string,int]" %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 

--- a/cl/_testrt/tpfunc/in.go
+++ b/cl/_testrt/tpfunc/in.go
@@ -5,13 +5,13 @@ import (
 	"unsafe"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpfunc.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/tpfunc.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/tpfunc.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -26,7 +26,7 @@ type CFunc func(*int)
 //llgo:type C
 type Callback[T any] func(*T)
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpfunc.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintUint"(i64 16)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
@@ -38,7 +38,7 @@ type Callback[T any] func(*T)
 // CHECK-NEXT: }
 
 func main() {
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpfunc.main$1"(ptr %0){{.*}} {
+	// CHECK-LABEL: define void @"main.main$1"(ptr %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = icmp eq ptr %0, null
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
@@ -52,7 +52,7 @@ func main() {
 		println(*v)
 	}
 
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpfunc.main$2"(ptr %0){{.*}} {
+	// CHECK-LABEL: define void @"main.main$2"(ptr %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = icmp eq ptr %0, null
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
@@ -66,7 +66,7 @@ func main() {
 		println(*v)
 	}
 
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpfunc.main$3"(ptr %0){{.*}} {
+	// CHECK-LABEL: define void @"main.main$3"(ptr %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = icmp eq ptr %0, null
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
@@ -82,8 +82,8 @@ func main() {
 	println(unsafe.Sizeof(fn1), unsafe.Sizeof(fn2), unsafe.Sizeof(fn3))
 }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/tpfunc.main$1"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.main$1"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/tpfunc.main$1"(ptr %1)
+// CHECK-NEXT:   tail call void @"main.main$1"(ptr %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/tpmap/in.go
+++ b/cl/_testrt/tpmap/in.go
@@ -19,18 +19,18 @@ type cacheKey struct {
 	t5 uintptr
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmap.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/tpmap.cacheKey]_llgo_string", i64 0)
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/tpmap.cacheKey", align 8
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_main.cacheKey]_llgo_string", i64 0)
+// CHECK-NEXT:   %1 = alloca %main.cacheKey, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 48, i1 false)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %1, i32 0, i32 1
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.T2", ptr %3, i32 0, i32 0
-// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %1, i32 0, i32 2
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.T3[any]", ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %1, i32 0, i32 3
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %1, i32 0, i32 4
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.cacheKey, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %main.cacheKey, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.T2, ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %main.cacheKey, ptr %1, i32 0, i32 2
+// CHECK-NEXT:   %6 = getelementptr inbounds %"main.T3[any]", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %main.cacheKey, ptr %1, i32 0, i32 3
+// CHECK-NEXT:   %8 = getelementptr inbounds %main.cacheKey, ptr %1, i32 0, i32 4
 // CHECK-NEXT:   store i64 0, ptr %2, align 8
 // CHECK-NEXT:   store i64 0, ptr %4, align 8
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
@@ -39,20 +39,20 @@ type cacheKey struct {
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %10, ptr %6, align 8
 // CHECK-NEXT:   store ptr null, ptr %7, align 8
 // CHECK-NEXT:   store i64 0, ptr %8, align 8
-// CHECK-NEXT:   %11 = load %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %1, align 8
+// CHECK-NEXT:   %11 = load %main.cacheKey, ptr %1, align 8
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/tpmap.cacheKey" %11, ptr %12, align 8
-// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/tpmap.cacheKey]_llgo_string", ptr %0, ptr %12)
+// CHECK-NEXT:   store %main.cacheKey %11, ptr %12, align 8
+// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_main.cacheKey]_llgo_string", ptr %0, ptr %12)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 5 }, ptr %13, align 8
-// CHECK-NEXT:   %14 = alloca %"{{.*}}/cl/_testrt/tpmap.cacheKey", align 8
+// CHECK-NEXT:   %14 = alloca %main.cacheKey, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %14, i8 0, i64 48, i1 false)
-// CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %14, i32 0, i32 0
-// CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %14, i32 0, i32 1
-// CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.T2", ptr %16, i32 0, i32 0
-// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %14, i32 0, i32 2
-// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.T3[any]", ptr %18, i32 0, i32 0
-// CHECK-NEXT:   %20 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %14, i32 0, i32 3
-// CHECK-NEXT:   %21 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %14, i32 0, i32 4
+// CHECK-NEXT:   %15 = getelementptr inbounds %main.cacheKey, ptr %14, i32 0, i32 0
+// CHECK-NEXT:   %16 = getelementptr inbounds %main.cacheKey, ptr %14, i32 0, i32 1
+// CHECK-NEXT:   %17 = getelementptr inbounds %main.T2, ptr %16, i32 0, i32 0
+// CHECK-NEXT:   %18 = getelementptr inbounds %main.cacheKey, ptr %14, i32 0, i32 2
+// CHECK-NEXT:   %19 = getelementptr inbounds %"main.T3[any]", ptr %18, i32 0, i32 0
+// CHECK-NEXT:   %20 = getelementptr inbounds %main.cacheKey, ptr %14, i32 0, i32 3
+// CHECK-NEXT:   %21 = getelementptr inbounds %main.cacheKey, ptr %14, i32 0, i32 4
 // CHECK-NEXT:   store i64 0, ptr %15, align 8
 // CHECK-NEXT:   store i64 0, ptr %17, align 8
 // CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
@@ -61,10 +61,10 @@ type cacheKey struct {
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %23, ptr %19, align 8
 // CHECK-NEXT:   store ptr null, ptr %20, align 8
 // CHECK-NEXT:   store i64 0, ptr %21, align 8
-// CHECK-NEXT:   %24 = load %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %14, align 8
+// CHECK-NEXT:   %24 = load %main.cacheKey, ptr %14, align 8
 // CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/tpmap.cacheKey" %24, ptr %25, align 8
-// CHECK-NEXT:   %26 = call { ptr, i1 } @"{{.*}}/runtime/internal/runtime.MapAccess2"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/tpmap.cacheKey]_llgo_string", ptr %0, ptr %25)
+// CHECK-NEXT:   store %main.cacheKey %24, ptr %25, align 8
+// CHECK-NEXT:   %26 = call { ptr, i1 } @"{{.*}}/runtime/internal/runtime.MapAccess2"(ptr @"map[_llgo_main.cacheKey]_llgo_string", ptr %0, ptr %25)
 // CHECK-NEXT:   %27 = extractvalue { ptr, i1 } %26, 0
 // CHECK-NEXT:   %28 = load %"{{.*}}/runtime/internal/runtime.String", ptr %27, align 8
 // CHECK-NEXT:   %29 = extractvalue { ptr, i1 } %26, 1

--- a/cl/_testrt/tpmethod/in.go
+++ b/cl/_testrt/tpmethod/in.go
@@ -2,8 +2,8 @@
 package main
 
 // CHECK: {{^}}@0 = private unnamed_addr constant [7 x i8] c"foo.txt", align 1{{$}}
+// CHECK: {{^}}@6 = private unnamed_addr constant [17 x i8] c"main.Tuple[error]", align 1{{$}}
 // CHECK: {{^}}@7 = private unnamed_addr constant [3 x i8] c"Get", align 1{{$}}
-// CHECK: {{^}}@16 = private unnamed_addr constant [55 x i8] c"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", align 1{{$}}
 
 type Tuple[T any] struct {
 	v T
@@ -29,33 +29,33 @@ func Async[T any](fn func(func(T))) Future[T] {
 	return &future[T]{fn: fn}
 }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.ReadFile"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @main.ReadFile(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Async[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testrt/tpmethod.ReadFile$1", ptr null })
+// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.iface" @"main.Async[main.Tuple[error]]"({ ptr, ptr } { ptr @"__llgo_stub.main.ReadFile$1", ptr null })
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %1
 // CHECK-NEXT: }
 
 func ReadFile(fileName string) Future[Tuple[error]] {
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmethod.ReadFile$1"({ ptr, ptr } %0){{.*}} {
+	// CHECK-LABEL: define void @"main.ReadFile$1"({ ptr, ptr } %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", align 8
+	// CHECK-NEXT:   %1 = alloca %"main.Tuple[error]", align 8
 	// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-	// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %1, i32 0, i32 0
+	// CHECK-NEXT:   %2 = getelementptr inbounds %"main.Tuple[error]", ptr %1, i32 0, i32 0
 	// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer, ptr %2, align 8
-	// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %1, align 8
+	// CHECK-NEXT:   %3 = load %"main.Tuple[error]", ptr %1, align 8
 	// CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %0, 1
 	// CHECK-NEXT:   %5 = extractvalue { ptr, ptr } %0, 0
-	// CHECK-NEXT:   call void %5(ptr %4, %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %3)
+	// CHECK-NEXT:   call void %5(ptr %4, %"main.Tuple[error]" %3)
 	// CHECK-NEXT:   ret void
 	// CHECK-NEXT: }
 
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmethod.init"(){{.*}} {
+	// CHECK-LABEL: define void @main.init(){{.*}} {
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/tpmethod.init$guard", align 1
+	// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 	// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 	// CHECK-EMPTY:
 	// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-	// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/tpmethod.init$guard", align 1
+	// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 	// CHECK-NEXT:   br label %_llgo_2
 	// CHECK-EMPTY:
 	// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -67,9 +67,9 @@ func ReadFile(fileName string) Future[Tuple[error]] {
 	})
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmethod.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.ReadFile"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 7 })
+// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.iface" @main.ReadFile(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 7 })
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %0)
 // CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %0, 0
 // CHECK-NEXT:   %3 = getelementptr ptr, ptr %2, i64 3
@@ -78,14 +78,14 @@ func ReadFile(fileName string) Future[Tuple[error]] {
 // CHECK-NEXT:   %6 = insertvalue { ptr, ptr } %5, ptr %1, 1
 // CHECK-NEXT:   %7 = extractvalue { ptr, ptr } %6, 1
 // CHECK-NEXT:   %8 = extractvalue { ptr, ptr } %6, 0
-// CHECK-NEXT:   call void %8(ptr %7, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testrt/tpmethod.main$1", ptr null })
+// CHECK-NEXT:   call void %8(ptr %7, { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
 func main() {
-	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmethod.main$1"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %0){{.*}} {
+	// CHECK-LABEL: define void @"main.main$1"(%"main.Tuple[error]" %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Tuple[error].Get"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %0)
+	// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.iface" @"main.Tuple[error].Get"(%"main.Tuple[error]" %0)
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintIface"(%"{{.*}}/runtime/internal/runtime.iface" %1)
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 	// CHECK-NEXT:   ret void
@@ -96,42 +96,42 @@ func main() {
 	})
 }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Async[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } %0){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"main.Async[main.Tuple[error]]"({ ptr, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.future[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.future[main.Tuple[error]]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store { ptr, ptr } %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$S25w7h931TxiY5HCyBzDrZdIDRx-V5waLTlYXjrsYWc", ptr @"*_llgo_{{.*}}/cl/_testrt/tpmethod.future[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]")
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface${{[-A-Za-z0-9_]+}}", ptr @"*_llgo_main.future[main.Tuple[error]]")
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %3, 0
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %4, ptr %1, 1
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/tpmethod.ReadFile$1"(ptr %0, { ptr, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.ReadFile$1"(ptr %0, { ptr, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/tpmethod.ReadFile$1"({ ptr, ptr } %1)
+// CHECK-NEXT:   tail call void @"main.ReadFile$1"({ ptr, ptr } %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/tpmethod.main$1"(ptr %0, %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.main.main$1"(ptr %0, %"main.Tuple[error]" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/tpmethod.main$1"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %1)
+// CHECK-NEXT:   tail call void @"main.main$1"(%"main.Tuple[error]" %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Tuple[error].Get"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %0){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"main.Tuple[error].Get"(%"main.Tuple[error]" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", align 8
+// CHECK-NEXT:   %1 = alloca %"main.Tuple[error]", align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %"main.Tuple[error]" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.Tuple[error]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpmethod.(*future[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]).Then"(ptr %0, { ptr, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.(*future[main.Tuple[error]]).Then"(ptr %0, { ptr, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.future[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"main.future[main.Tuple[error]]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load { ptr, ptr }, ptr %2, align 8
 // CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %3, 1
 // CHECK-NEXT:   %5 = extractvalue { ptr, ptr } %3, 0
@@ -139,12 +139,12 @@ func main() {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.(*Tuple[error]).Get"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"main.(*Tuple[error]).Get"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 55 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 3 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %0, align 8
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Tuple[error].Get"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %2)
+// CHECK-NEXT:   %2 = load %"main.Tuple[error]", ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"main.Tuple[error].Get"(%"main.Tuple[error]" %2)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 

--- a/cl/_testrt/tpunsafe/in.go
+++ b/cl/_testrt/tpunsafe/in.go
@@ -16,12 +16,12 @@ type M[T any] struct {
 	m2 N[T]
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpunsafe.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 12)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/tpunsafe.(*M[bool]).check"(ptr %0, i64 1, i64 8, i64 1)
+// CHECK-NEXT:   call void @"main.(*M[bool]).check"(ptr %0, i64 1, i64 8, i64 1)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/tpunsafe.(*M[int64]).check"(ptr %1, i64 8, i64 16, i64 8)
+// CHECK-NEXT:   call void @"main.(*M[int64]).check"(ptr %1, i64 8, i64 16, i64 8)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {
@@ -31,10 +31,10 @@ func main() {
 	m2.check(8, 16, 8)
 }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpunsafe.(*M[bool]).check"(ptr %0, i64 %1, i64 %2, i64 %3){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.(*M[bool]).check"(ptr %0, i64 %1, i64 %2, i64 %3){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpunsafe.M[bool]", ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %5 = load %"{{.*}}/cl/_testrt/tpunsafe.N[bool]", ptr %4, align 1
+// CHECK-NEXT:   %4 = getelementptr inbounds %"main.M[bool]", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %5 = load %"main.N[bool]", ptr %4, align 1
 // CHECK-NEXT:   %6 = icmp ne i64 1, %1
 // CHECK-NEXT:   br i1 %6, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
@@ -54,8 +54,8 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpunsafe.M[bool]", ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testrt/tpunsafe.N[bool]", ptr %9, align 1
+// CHECK-NEXT:   %9 = getelementptr inbounds %"main.M[bool]", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %10 = load %"main.N[bool]", ptr %9, align 1
 // CHECK-NEXT:   %11 = icmp ne i64 8, %2
 // CHECK-NEXT:   br i1 %11, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
@@ -75,8 +75,8 @@ func main() {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpunsafe.M[bool]", ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpunsafe.N[bool]", ptr %14, i32 0, i32 1
+// CHECK-NEXT:   %14 = getelementptr inbounds %"main.M[bool]", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %15 = getelementptr inbounds %"main.N[bool]", ptr %14, i32 0, i32 1
 // CHECK-NEXT:   %16 = load i1, ptr %15, align 1
 // CHECK-NEXT:   %17 = icmp ne i64 1, %3
 // CHECK-NEXT:   br i1 %17, label %_llgo_5, label %_llgo_6
@@ -114,10 +114,10 @@ func (m *M[T]) check(align, offset1, offset2 uintptr) {
 	}
 }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpunsafe.(*M[int64]).check"(ptr %0, i64 %1, i64 %2, i64 %3){{.*}} {
+// CHECK-LABEL: define linkonce void @"main.(*M[int64]).check"(ptr %0, i64 %1, i64 %2, i64 %3){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpunsafe.M[int64]", ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %5 = load %"{{.*}}/cl/_testrt/tpunsafe.N[int64]", ptr %4, align 8
+// CHECK-NEXT:   %4 = getelementptr inbounds %"main.M[int64]", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %5 = load %"main.N[int64]", ptr %4, align 8
 // CHECK-NEXT:   %6 = icmp ne i64 8, %1
 // CHECK-NEXT:   br i1 %6, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
@@ -137,8 +137,8 @@ func (m *M[T]) check(align, offset1, offset2 uintptr) {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpunsafe.M[int64]", ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testrt/tpunsafe.N[int64]", ptr %9, align 8
+// CHECK-NEXT:   %9 = getelementptr inbounds %"main.M[int64]", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %10 = load %"main.N[int64]", ptr %9, align 8
 // CHECK-NEXT:   %11 = icmp ne i64 16, %2
 // CHECK-NEXT:   br i1 %11, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
@@ -158,8 +158,8 @@ func (m *M[T]) check(align, offset1, offset2 uintptr) {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpunsafe.M[int64]", ptr %0, i32 0, i32 2
-// CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpunsafe.N[int64]", ptr %14, i32 0, i32 1
+// CHECK-NEXT:   %14 = getelementptr inbounds %"main.M[int64]", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %15 = getelementptr inbounds %"main.N[int64]", ptr %14, i32 0, i32 1
 // CHECK-NEXT:   %16 = load i64, ptr %15, align 8
 // CHECK-NEXT:   %17 = icmp ne i64 8, %3
 // CHECK-NEXT:   br i1 %17, label %_llgo_5, label %_llgo_6

--- a/cl/_testrt/typalias/in.go
+++ b/cl/_testrt/typalias/in.go
@@ -14,7 +14,7 @@ type Foo = struct {
 
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/typalias.Print"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @main.Print(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load i1, ptr %1, align 1
@@ -23,7 +23,7 @@ var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %3 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %4 = load i32, ptr %3, align 4
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}/cl/_testrt/typalias.format", i32 %4)
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @main.format, i32 %4)
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -36,14 +36,14 @@ func Print(p *Foo) {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/typalias.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i32 100, ptr %1, align 4
 // CHECK-NEXT:   store i1 true, ptr %2, align 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/typalias.Print"(ptr %0)
+// CHECK-NEXT:   call void @main.Print(ptr %0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 func main() {

--- a/cl/_testrt/typed/in.go
+++ b/cl/_testrt/typed/in.go
@@ -2,15 +2,15 @@
 package main
 
 // CHECK: @0 = private unnamed_addr constant [5 x i8] c"hello", align 1
-// CHECK: @3 = private unnamed_addr constant [41 x i8] c"{{.*}}/cl/_testrt/typed.T", align 1
+// CHECK: @1 = private unnamed_addr constant [6 x i8] c"main.T", align 1
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/typed.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/typed.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/typed.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -20,13 +20,13 @@ package main
 type T string
 type A [2]int
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/typed.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/typed.T", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.T, ptr undef }, ptr %0, 1
 // CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %1, 0
-// CHECK-NEXT:   %3 = icmp eq ptr %2, @"_llgo_{{.*}}/cl/_testrt/typed.T"
+// CHECK-NEXT:   %3 = icmp eq ptr %2, @_llgo_main.T
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
@@ -69,11 +69,11 @@ type A [2]int
 // CHECK-NEXT:   %18 = load [2 x i64], ptr %15, align 8
 // CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   store [2 x i64] %18, ptr %19, align 8
-// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/typed.A", ptr undef }, ptr %19, 1
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_main.A, ptr undef }, ptr %19, 1
 // CHECK-NEXT:   %21 = alloca [2 x i64], align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %21, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %22 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %20, 0
-// CHECK-NEXT:   %23 = icmp eq ptr %22, @"_llgo_{{.*}}/cl/_testrt/typed.A"
+// CHECK-NEXT:   %23 = icmp eq ptr %22, @_llgo_main.A
 // CHECK-NEXT:   br i1 %23, label %_llgo_6, label %_llgo_7
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5

--- a/cl/_testrt/unreachable/in.go
+++ b/cl/_testrt/unreachable/in.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/unreachable.foo"(){{.*}} {
+// CHECK-LABEL: define void @main.foo(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT:   ret void
@@ -14,9 +14,9 @@ func foo() {
 	c.Unreachable()
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/unreachable.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/unreachable.foo"()
+// CHECK-NEXT:   call void @main.foo()
 // CHECK-NEXT:   %0 = call i32 (ptr, ...) @printf(ptr @0)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testrt/unsafe/in.go
+++ b/cl/_testrt/unsafe/in.go
@@ -15,13 +15,13 @@ import (
 // CHECK: {{^}}@6 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1{{$}}
 // CHECK: {{^}}@7 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1{{$}}
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/unsafe.init"(){{.*}} {
+// CHECK-LABEL: define void @main.init(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/unsafe.init$guard", align 1
+// CHECK-NEXT:   %0 = load i1, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/unsafe.init$guard", align 1
+// CHECK-NEXT:   store i1 true, ptr @"main.init$guard", align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -41,7 +41,7 @@ type N struct {
 	v  int
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/unsafe.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   br i1 false, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:

--- a/cl/_testrt/vamethod/in.go
+++ b/cl/_testrt/vamethod/in.go
@@ -7,28 +7,28 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/vamethod.CFmt.Printf"(%"{{.*}}/cl/_testrt/vamethod.CFmt" %0, ...){{.*}} {
+// CHECK-LABEL: define i32 @main.CFmt.Printf(%main.CFmt %0, ...){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/vamethod.CFmt", align 8
+// CHECK-NEXT:   %1 = alloca %main.CFmt, align 8
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/vamethod.CFmt" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/vamethod.CFmt", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %main.CFmt %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.CFmt, ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call i32 (ptr, ...) @printf(ptr %3)
 // CHECK-NEXT:   ret i32 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/vamethod.(*CFmt).Printf"(ptr %0, ...){{.*}} {
+// CHECK-LABEL: define i32 @"main.(*CFmt).Printf"(ptr %0, ...){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/vamethod.CFmt", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.CFmt, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
 // CHECK-NEXT:   %3 = call i32 (ptr, ...) @printf(ptr %2)
 // CHECK-NEXT:   ret i32 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/vamethod.(*CFmt).SetFormat"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define void @"main.(*CFmt).SetFormat"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/vamethod.CFmt", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %main.CFmt, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store ptr %1, ptr %2, align 8
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -54,21 +54,21 @@ type IFmt interface {
 	Printf(__llgo_va_list ...any) c.Int
 }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/vamethod.main"(){{.*}} {
+// CHECK-LABEL: define void @main.main(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/vamethod.(*CFmt).SetFormat"(ptr %0, ptr @0)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/vamethod.CFmt", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   call void @"main.(*CFmt).SetFormat"(ptr %0, ptr @0)
+// CHECK-NEXT:   %1 = getelementptr inbounds %main.CFmt, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
 // CHECK-NEXT:   %3 = call i32 (ptr, ...) @printf(ptr %2, ptr @1, i64 100)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/vamethod.(*CFmt).SetFormat"(ptr %0, ptr @2)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/vamethod.CFmt", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   call void @"main.(*CFmt).SetFormat"(ptr %0, ptr @2)
+// CHECK-NEXT:   %4 = getelementptr inbounds %main.CFmt, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %5 = load ptr, ptr %4, align 8
 // CHECK-NEXT:   %6 = call i32 (ptr, ...) @printf(ptr %5, i64 200, ptr @3)
 // CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_github.com/goplus/llgo/cl/_testrt/vamethod.CFmt", ptr undef }, ptr %7, 1
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_main.CFmt", ptr undef }, ptr %7, 1
 // CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %8, 0
-// CHECK-NEXT:   %10 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/vamethod.IFmt", ptr %9)
+// CHECK-NEXT:   %10 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @_llgo_main.IFmt, ptr %9)
 // CHECK-NEXT:   br i1 %10, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5

--- a/cl/caller_frame_test.go
+++ b/cl/caller_frame_test.go
@@ -993,8 +993,8 @@ func TestFuncInfoDisplayName(t *testing.T) {
 		pkg      *types.Package
 		in, want string
 	}{
-		{mainPkg, "example.com/cmd.main", "main.main"},
-		{mainPkg, "example.com/cmd.main$2", "main.main.func2"},
+		{mainPkg, "main.main", "main.main"},
+		{mainPkg, "main.main$2", "main.main.func2"},
 		{mainPkg, "other/path.f", "other/path.f"},
 		{libPkg, "example.com/lib.f$1", "example.com/lib.f.func1"},
 		{nil, "plain.f$x", "plain.f$x"},

--- a/cl/caller_frame_test.go
+++ b/cl/caller_frame_test.go
@@ -984,23 +984,20 @@ func helper() {}
 	}
 }
 
-// Display names follow gc's reporting conventions regardless of the module
-// path; linker symbols are untouched.
+// Anonymous function display names follow gc's reporting convention; linker
+// symbols are untouched.
 func TestFuncInfoDisplayName(t *testing.T) {
-	mainPkg := types.NewPackage("example.com/cmd", "main")
-	libPkg := types.NewPackage("example.com/lib", "lib")
 	cases := []struct {
-		pkg      *types.Package
 		in, want string
 	}{
-		{mainPkg, "main.main", "main.main"},
-		{mainPkg, "main.main$2", "main.main.func2"},
-		{mainPkg, "other/path.f", "other/path.f"},
-		{libPkg, "example.com/lib.f$1", "example.com/lib.f.func1"},
-		{nil, "plain.f$x", "plain.f$x"},
+		{"main.main", "main.main"},
+		{"main.main$2", "main.main.func2"},
+		{"other/path.f", "other/path.f"},
+		{"example.com/lib.f$1", "example.com/lib.f.func1"},
+		{"plain.f$x", "plain.f$x"},
 	}
 	for _, c := range cases {
-		if got := funcInfoDisplayName(c.pkg, c.in); got != c.want {
+		if got := funcInfoDisplayName(c.in); got != c.want {
 			t.Fatalf("funcInfoDisplayName(%q) = %q, want %q", c.in, got, c.want)
 		}
 	}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -578,7 +578,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 				goName = funcName(pkgTypes, f, false)
 			}
 			pos := p.funcInfoPosition(f)
-			pkg.EmitFuncInfo(fn.Name(), funcInfoDisplayName(pkgTypes, goName), pos.Filename, pos.Line, pos.Column)
+			pkg.EmitFuncInfo(fn.Name(), funcInfoDisplayName(goName), pos.Filename, pos.Line, pos.Column)
 		}
 		var childInits []func()
 		if len(f.AnonFuncs) > 0 {
@@ -671,17 +671,10 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 	return fn, nil, goFunc
 }
 
-// funcInfoDisplayName normalizes a funcinfo metadata display name to gc's
-// reporting conventions: the main package is "main" no matter what the
-// module names it (frame filters in the wild match on the "main." prefix),
-// and anonymous functions are pkg.fn.funcN (our linker symbols use $N).
-// Linker symbols are not affected.
-func funcInfoDisplayName(pkgTypes *types.Package, goName string) string {
-	if pkgTypes != nil && pkgTypes.Name() == "main" {
-		if path := llssa.PathOf(pkgTypes); path != "main" && strings.HasPrefix(goName, path+".") {
-			goName = "main" + goName[len(path):]
-		}
-	}
+// funcInfoDisplayName normalizes anonymous functions to gc's pkg.fn.funcN
+// reporting convention (our linker symbols use $N). Linker symbols are not
+// affected.
+func funcInfoDisplayName(goName string) string {
 	return normalizeRuntimeAnonFuncName(goName)
 }
 

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -251,6 +251,10 @@ func TestBuildAndCheckSymbolsFromTestlto(t *testing.T) {
 	}
 	conf := build.NewDefaultConf(build.ModeBuild)
 	conf.LTO = lto.Full
+	// Linux exports main.* when PCLN is enabled so runtime funcinfo can resolve
+	// symbols. Disable that retention here so the final symbol table measures
+	// GlobalDCE rather than the executable's dynamic-export policy.
+	conf.PCLNMode = build.PCLNNone
 	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoSymbolChecks, cltest.WithRunConfig(conf))
 }
 
@@ -279,6 +283,9 @@ func TestRunAndTestFromTestltoLTOPlugin(t *testing.T) {
 
 func TestBuildAndCheckSymbolsFromTestltoLTOPlugin(t *testing.T) {
 	buildConf := testltoLTOPluginConf(t, build.ModeBuild)
+	// See TestBuildAndCheckSymbolsFromTestlto: dynamic main.* exports retain
+	// otherwise-dead symbols on Linux and would mask the plugin's DCE result.
+	buildConf.PCLNMode = build.PCLNNone
 	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoLTOPluginTests,
 		cltest.WithRunConfig(buildConf),
 	)

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -51,7 +51,6 @@ var PrintCommands bool
 var DeadcodeDrop bool
 var PthreadStackSize byteSizeFlag
 var OptLevel optlevel.Level
-var RewriteMainPrefix bool = true
 
 type byteSizeFlag int64
 
@@ -230,7 +229,6 @@ func AddBuildFlags(fs *flag.FlagSet) {
 		fs.BoolVar(&CheckLLFiles, "check-llfiles", false, "check .ll files valid")
 		fs.BoolVar(&GenLLFiles, "gen-llfiles", false, "generate .ll files for pkg export")
 		fs.BoolVar(&ForceEspClang, "force-espclang", false, "force to use esp-clang")
-		fs.BoolVar(&RewriteMainPrefix, "rewrite-main-prefix", true, "Rewrite symbol names in the main package from 'pkgpath.sym' to 'main.sym'")
 	}
 
 	fs.BoolVar(&SizeReport, "size", false, "Print size report after build (default format=text, level=module)")
@@ -425,7 +423,6 @@ func UpdateConfig(conf *build.Config) error {
 		conf.GenLL = GenLLFiles
 		conf.ForceEspClang = ForceEspClang
 	}
-	conf.RewriteMainPrefix = RewriteMainPrefix
 	return nil
 }
 

--- a/internal/build/bounds_checks_test.go
+++ b/internal/build/bounds_checks_test.go
@@ -114,7 +114,7 @@ func boundsChecksModuleIR(t *testing.T, disable bool) string {
 	var ir string
 	conf.ModuleHook = func(pkg Package) {
 		module := pkg.LPkg.String()
-		if strings.Contains(module, ".indexString\"") {
+		if strings.Contains(module, "main.indexString(") || strings.Contains(module, ".indexString\"(") {
 			ir = module
 		}
 	}
@@ -158,28 +158,26 @@ func buildBoundsChecksBinaryFrom(t *testing.T, fixture string, disable bool) str
 
 func llvmFunctionBody(t *testing.T, module, name string) string {
 	t.Helper()
-	marker := "." + name + "\"("
-	markerAt := 0
-	start := -1
-	for {
-		next := strings.Index(module[markerAt:], marker)
-		if next < 0 {
-			break
+	markers := []string{"." + name + "\"(", "." + name + "("}
+	for _, marker := range markers {
+		markerAt := 0
+		for {
+			next := strings.Index(module[markerAt:], marker)
+			if next < 0 {
+				break
+			}
+			markerAt += next
+			lineStart := strings.LastIndex(module[:markerAt], "\n") + 1
+			if strings.HasPrefix(module[lineStart:markerAt], "define ") {
+				end := strings.Index(module[markerAt:], "\n}")
+				if end < 0 {
+					t.Fatalf("end of LLVM definition for %q not found", name)
+				}
+				return module[lineStart : markerAt+end+2]
+			}
+			markerAt += len(marker)
 		}
-		markerAt += next
-		lineStart := strings.LastIndex(module[:markerAt], "\n") + 1
-		if strings.HasPrefix(module[lineStart:markerAt], "define ") {
-			start = lineStart
-			break
-		}
-		markerAt += len(marker)
 	}
-	if start < 0 {
-		t.Fatalf("LLVM definition for %q not found", name)
-	}
-	end := strings.Index(module[markerAt:], "\n}")
-	if end < 0 {
-		t.Fatalf("end of LLVM definition for %q not found", name)
-	}
-	return module[start : markerAt+end+2]
+	t.Fatalf("LLVM definition for %q not found", name)
+	return ""
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -195,11 +195,6 @@ type Config struct {
 	// when it would otherwise be enabled by full LTO.
 	DisableGoGlobalDCE bool
 
-	// RewriteMainPrefix controls whether symbols in the main package
-	// use "main." as their package path prefix instead of the actual
-	// import path. When true, pkgpath.sym is rewritten to main.sym.
-	RewriteMainPrefix bool
-
 	// GlobalRewrites specifies compile-time overrides for global string variables.
 	// Keys are fully qualified package paths (e.g. "main" or "github.com/user/pkg").
 	// Each Rewrites entry maps variable names to replacement string values. Only
@@ -432,8 +427,6 @@ func Build(inv Invocation) ([]Package, error) {
 	if conf.Mode == ModeTest {
 		cfg.Mode |= packages.NeedForTest
 	}
-	abi.SetRewriteMainPrefix(conf.RewriteMainPrefix)
-
 	emitDebugInfo := shouldEmitDebugInfo(conf, &export)
 	cl.EnableDebug(emitDebugInfo)
 	cl.EnableDbgSyms(emitDebugInfo)
@@ -541,7 +534,7 @@ func Build(inv Invocation) ([]Package, error) {
 	}
 	mode := conf.Mode
 	if mode == ModeTest {
-		initial, err = filterTestPackages(initial, conf.OutFile, conf.RewriteMainPrefix)
+		initial, err = filterTestPackages(initial, conf.OutFile)
 		if err != nil {
 			return nil, err
 		}
@@ -820,13 +813,13 @@ func needLink(pkg *packages.Package, mode Mode) bool {
 	return pkg.Name == "main"
 }
 
-func filterTestPackages(initial []*packages.Package, outFile string, rewriteMainPrefix bool) ([]*packages.Package, error) {
+func filterTestPackages(initial []*packages.Package, outFile string) ([]*packages.Package, error) {
 	filtered := initial[:0]
 	for _, pkg := range initial {
 		if needLink(pkg, ModeTest) {
 			filtered = append(filtered, pkg)
 		}
-		if rewriteMainPrefix && pkg.Types != nil && pkg.Types.Name() == "main" {
+		if pkg.Types != nil && pkg.Types.Name() == "main" {
 			pkg.Types.SetName("main.test")
 		}
 	}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -511,7 +511,7 @@ func TestFilterTestPackages(t *testing.T) {
 			pkg("github.com/goplus/llgo/chore/ardump"),
 			pkg("github.com/goplus/llgo/chore/ardump [github.com/goplus/llgo/chore/ardump.test]"),
 		}
-		filtered, err := filterTestPackages(initial, "", false)
+		filtered, err := filterTestPackages(initial, "")
 		if err != nil {
 			t.Fatalf("filterTestPackages returned unexpected error: %v", err)
 		}
@@ -525,7 +525,7 @@ func TestFilterTestPackages(t *testing.T) {
 			pkg("foo"),
 			pkg("foo.test"),
 		}
-		filtered, err := filterTestPackages(initial, "", false)
+		filtered, err := filterTestPackages(initial, "")
 		if err != nil {
 			t.Fatalf("filterTestPackages returned unexpected error: %v", err)
 		}
@@ -537,12 +537,31 @@ func TestFilterTestPackages(t *testing.T) {
 		}
 	})
 
+	t.Run("rename main package", func(t *testing.T) {
+		mainPkg := pkg("example.com/cmd")
+		mainPkg.Types = types.NewPackage(mainPkg.ID, "main")
+		initial := []*packages.Package{
+			mainPkg,
+			pkg("example.com/cmd.test"),
+		}
+		filtered, err := filterTestPackages(initial, "")
+		if err != nil {
+			t.Fatalf("filterTestPackages returned unexpected error: %v", err)
+		}
+		if len(filtered) != 1 || filtered[0].ID != "example.com/cmd.test" {
+			t.Fatalf("filtered = %#v, want only example.com/cmd.test", filtered)
+		}
+		if got := mainPkg.Types.Name(); got != "main.test" {
+			t.Fatalf("main package name = %q, want %q", got, "main.test")
+		}
+	})
+
 	t.Run("multiple test packages with output file", func(t *testing.T) {
 		initial := []*packages.Package{
 			pkg("a.test"),
 			pkg("b.test"),
 		}
-		_, err := filterTestPackages(initial, "/tmp/out", false)
+		_, err := filterTestPackages(initial, "/tmp/out")
 		if err == nil {
 			t.Fatal("expected error for -o with multiple test packages, got nil")
 		}

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -103,7 +103,7 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 	}
 
 	var pkgPath string
-	if ctx.buildConf.RewriteMainPrefix && pkg.Types.Name() == "main" {
+	if pkg.Types != nil && pkg.Types.Name() == "main" {
 		pkgPath = "main"
 	} else {
 		pkgPath = pkg.PkgPath

--- a/internal/cabi/cabi_test.go
+++ b/internal/cabi/cabi_test.go
@@ -154,12 +154,15 @@ func testModule(t *testing.T, ctx context, td llvm.TargetData, m llvm.Module, c 
 	for _, fn := range fns {
 		// check c linkname
 		testFunc(t, ctx, td, m.NamedFunction(fn.Name()), fn)
-		// check go
-		testFunc(t, ctx, td, m.NamedFunction("command-line-arguments."+fn.Name()), fn)
+		// check Go symbol
+		testFunc(t, ctx, td, m.NamedFunction("main."+fn.Name()), fn)
 	}
 }
 
 func testFunc(t *testing.T, ctx context, td llvm.TargetData, fn llvm.Value, cfn llvm.Value) {
+	if fn.IsNil() {
+		t.Fatalf("%v: function %q not found", ctx, cfn.Name())
+	}
 	ft := fn.GlobalValueType()
 	cft := cfn.GlobalValueType()
 	pts := ft.ParamTypes()

--- a/internal/llgen/llgenf.go
+++ b/internal/llgen/llgenf.go
@@ -28,7 +28,7 @@ import (
 )
 
 func GenFrom(fileOrPkg string) string {
-	pkg, err := genFrom(fileOrPkg, 0, false)
+	pkg, err := genFrom(fileOrPkg, 0)
 	check(err)
 	out := pkg.LPkg.String()
 	// Release the compile's LLVM context: golden suites call GenFrom for
@@ -38,12 +38,11 @@ func GenFrom(fileOrPkg string) string {
 	return out
 }
 
-func genFrom(pkgPath string, abiMode build.AbiMode, rewriteMainPrefix bool) (build.Package, error) {
+func genFrom(pkgPath string, abiMode build.AbiMode) (build.Package, error) {
 	conf := &build.Config{
-		Mode:              build.ModeGen,
-		AbiMode:           abiMode,
-		GenLL:             true,
-		RewriteMainPrefix: rewriteMainPrefix,
+		Mode:    build.ModeGen,
+		AbiMode: abiMode,
+		GenLL:   true,
 	}
 	if err := applyGoBuildFlagsFile(conf, filepath.Join(pkgPath, "flags.txt")); err != nil {
 		return nil, err
@@ -88,11 +87,11 @@ func applyGoBuildFlagsFile(conf *build.Config, flagsFile string) error {
 }
 
 func SmartDoFile(pkgPath string) {
-	SmartDoFileEx(pkgPath, 0, false)
+	SmartDoFileEx(pkgPath, 0)
 }
 
-func SmartDoFileEx(pkgPath string, abiMode build.AbiMode, rewriteMainPrefix bool) {
-	pkg, err := genFrom(pkgPath, abiMode, rewriteMainPrefix)
+func SmartDoFileEx(pkgPath string, abiMode build.AbiMode) {
+	pkg, err := genFrom(pkgPath, abiMode)
 	check(err)
 
 	const autgenFile = "llgo_autogen.ll"

--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -279,21 +279,12 @@ const (
 	PatchPathPrefix = env.LLGoRuntimePkg + "/internal/lib/"
 )
 
-// SetRewriteMainPrefix controls whether symbols in the main package
-// use "main." as their package path prefix instead of the actual
-// import path. When true, pkgpath.sym is rewritten to main.sym.
-func SetRewriteMainPrefix(b bool) {
-	rewriteMainPrefix = b
-}
-
-var rewriteMainPrefix bool
-
 // PathOf returns the package path of the specified package.
 func PathOf(pkg *types.Package) string {
 	if pkg == nil {
 		return ""
 	}
-	if rewriteMainPrefix && pkg.Name() == "main" {
+	if pkg.Name() == "main" {
 		return "main"
 	}
 	return strings.TrimPrefix(pkg.Path(), PatchPathPrefix)

--- a/ssa/abi/abi_test.go
+++ b/ssa/abi/abi_test.go
@@ -408,14 +408,9 @@ func isPaddedField(t reflect.Type, i int) bool {
 	return field.Offset+field.Type.Size() != t.Size()
 }
 
-func TestRewriteMainPrefix(t *testing.T) {
+func TestMainPackagePath(t *testing.T) {
 	pkg := types.NewPackage("example.com/foo/pkg", "main")
-	if path := abi.PathOf(pkg); path != "example.com/foo/pkg" {
-		t.Fatalf("error %v", path)
-	}
-	abi.SetRewriteMainPrefix(true)
 	if path := abi.PathOf(pkg); path != "main" {
-		t.Fatalf("error %v", path)
+		t.Fatalf("PathOf(main package) = %q, want main", path)
 	}
-	abi.SetRewriteMainPrefix(false)
 }


### PR DESCRIPTION
## Summary

- make packages named main always use the canonical main symbol prefix
- remove RewriteMainPrefix from build configuration, developer flags, llgen, and the global ABI switch
- keep synthesized test-main isolation by renaming the original main package to main.test
- refresh IR and metadata expectations for the now-unconditional naming behavior

This is an independent refactoring PR based directly on current main. It is not stacked on the package-parallel PR series.

## Validation

- go test ./internal/build ./cl ./ssa -count=1
- go test ./cl ./ssa -count=1 after all fixture refreshes
- go test -race ./ssa/abi -count=1
- go test -race ./internal/build -run ^TestFilterTestPackages$ -count=1
- go test ./ssa/abi ./cmd/internal/flags ./internal/llgen ./chore/llgen -count=1
- go test ./internal/build -run ^TestFilterTestPackages$ -count=1