### PR TITLE
cl: fold constant comparisons before lowering

### DIFF
--- a/cl/_testrt/builtin/in.go
+++ b/cl/_testrt/builtin/in.go
@@ -9,9 +9,7 @@ import (
 // CHECK: {{^}}@1 = private unnamed_addr constant [3 x i8] c"def", align 1{{$}}
 // CHECK: {{^}}@3 = private unnamed_addr constant [4 x i8] c"ABCD", align 1{{$}}
 // CHECK: {{^}}@4 = private unnamed_addr constant [7 x i8] c"\E4\B8\ADabcd", align 1{{$}}
-// CHECK: {{^}}@5 = private unnamed_addr constant [3 x i8] c"abc", align 1{{$}}
-// CHECK: {{^}}@6 = private unnamed_addr constant [3 x i8] c"abd", align 1{{$}}
-// CHECK: {{^}}@7 = private unnamed_addr constant [2 x i8] c"fn", align 1{{$}}
+// CHECK: {{^}}@5 = private unnamed_addr constant [2 x i8] c"fn", align 1{{$}}
 
 var a int64 = 1<<63 - 1
 var b int64 = -1 << 63
@@ -432,29 +430,19 @@ func demo() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %165)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %166 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 })
-// CHECK-NEXT:   %167 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 3 })
-// CHECK-NEXT:   %168 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 3 })
-// CHECK-NEXT:   %169 = xor i1 %168, true
-// CHECK-NEXT:   %170 = call i1 @"{{.*}}/runtime/internal/runtime.StringLess"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 3 })
-// CHECK-NEXT:   %171 = call i1 @"{{.*}}/runtime/internal/runtime.StringLess"(%"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 })
-// CHECK-NEXT:   %172 = xor i1 %171, true
-// CHECK-NEXT:   %173 = call i1 @"{{.*}}/runtime/internal/runtime.StringLess"(%"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 })
-// CHECK-NEXT:   %174 = call i1 @"{{.*}}/runtime/internal/runtime.StringLess"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 3 })
-// CHECK-NEXT:   %175 = xor i1 %174, true
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %166)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %167)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 false)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %169)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %170)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %172)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %173)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 false)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %175)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 false)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -496,7 +484,7 @@ func main() {
 
 	// CHECK-LABEL: define void @"main.main$2"(){{.*}} {
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 2 })
+	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 2 })
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 	// CHECK-NEXT:   ret void
 	// CHECK-NEXT: }

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1309,6 +1309,10 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 			b.DeferStackDrain()
 		}
 	case *ssa.BinOp:
+		if value, ok := foldConstComparison(v); ok {
+			ret = p.prog.BoolVal(value)
+			break
+		}
 		if isUntypedNilConst(v.X) && isUntypedNilConst(v.Y) {
 			switch v.Op {
 			case token.EQL:
@@ -1682,6 +1686,20 @@ func isUntypedNilConst(v ssa.Value) bool {
 	}
 	basic, ok := c.Type().Underlying().(*types.Basic)
 	return ok && basic.Kind() == types.UntypedNil
+}
+
+func foldConstComparison(v *ssa.BinOp) (bool, bool) {
+	switch v.Op {
+	case token.EQL, token.NEQ, token.LSS, token.LEQ, token.GTR, token.GEQ:
+	default:
+		return false, false
+	}
+	x, xok := v.X.(*ssa.Const)
+	y, yok := v.Y.(*ssa.Const)
+	if !xok || !yok || x.Value == nil || y.Value == nil {
+		return false, false
+	}
+	return constant.Compare(x.Value, v.Op, y.Value), true
 }
 
 func (p *context) nilOf(typ types.Type) llssa.Expr {

--- a/cl/compile_nil_test.go
+++ b/cl/compile_nil_test.go
@@ -7,6 +7,7 @@ import (
 	"go/constant"
 	"go/token"
 	"go/types"
+	"strings"
 	"testing"
 
 	llssa "github.com/goplus/llgo/ssa"
@@ -154,6 +155,55 @@ func iface(v int) any {
 	makeInterface.X = untypedNil
 	if ret := ctx.compileInstrOrValue(b, makeInterface, false); ret.IsNil() {
 		t.Fatal("MakeInterface untyped nil lowered to an empty expression")
+	}
+}
+
+func TestFoldConstComparison(t *testing.T) {
+	a := gossa.NewConst(constant.MakeString("a"), types.Typ[types.String])
+	b := gossa.NewConst(constant.MakeString("b"), types.Typ[types.String])
+	for _, tt := range []struct {
+		op   token.Token
+		want bool
+	}{
+		{token.EQL, false},
+		{token.NEQ, true},
+		{token.LSS, true},
+		{token.LEQ, true},
+		{token.GTR, false},
+		{token.GEQ, false},
+	} {
+		if got, ok := foldConstComparison(&gossa.BinOp{Op: tt.op, X: a, Y: b}); !ok || got != tt.want {
+			t.Errorf("foldConstComparison(%s) = %v, %v; want %v, true", tt.op, got, ok, tt.want)
+		}
+	}
+	if _, ok := foldConstComparison(&gossa.BinOp{Op: token.ADD, X: a, Y: b}); ok {
+		t.Fatal("non-comparison operation was folded")
+	}
+	if _, ok := foldConstComparison(&gossa.BinOp{Op: token.EQL, X: &gossa.Parameter{}, Y: b}); ok {
+		t.Fatal("non-constant operand was folded")
+	}
+	if _, ok := foldConstComparison(&gossa.BinOp{
+		Op: token.EQL,
+		X:  gossa.NewConst(nil, types.NewPointer(types.Typ[types.Int])),
+		Y:  gossa.NewConst(nil, types.NewPointer(types.Typ[types.Int])),
+	}); ok {
+		t.Fatal("nil comparison was folded through go/constant")
+	}
+}
+
+func TestCompileFoldsConstStringComparison(t *testing.T) {
+	_, mod := mustCompileLLPkgFromSrc(t, `
+package foo
+
+func equal() bool { return "a" == "b" }
+func less() bool  { return "a" < "b" }
+`)
+	ir := mod.String()
+	if strings.Contains(ir, "StringEqual") {
+		t.Fatalf("constant string comparison called the runtime helper:\n%s", ir)
+	}
+	if !strings.Contains(ir, "ret i1 false") || !strings.Contains(ir, "ret i1 true") {
+		t.Fatalf("constant string comparisons were not folded:\n%s", ir)
 	}
 }
 

--- a/cl/compile_nil_test.go
+++ b/cl/compile_nil_test.go
@@ -189,21 +189,60 @@ func TestFoldConstComparison(t *testing.T) {
 	}); ok {
 		t.Fatal("nil comparison was folded through go/constant")
 	}
+
+	for _, tt := range []struct {
+		name string
+		x, y constant.Value
+	}{
+		{"integer", constant.MakeInt64(0), constant.MakeInt64(1)},
+		{"string", constant.MakeString("a"), constant.MakeString("b")},
+		{"rune", constant.MakeInt64('☃'), constant.MakeInt64('☀')},
+		{"float", constant.MakeFloat64(0), constant.MakeFloat64(1)},
+		{
+			"complex",
+			constant.MakeFromLiteral("1i", token.IMAG, 0),
+			constant.MakeFromLiteral("-1i", token.IMAG, 0),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			typ := types.Typ[types.UntypedInt]
+			if tt.name == "string" {
+				typ = types.Typ[types.UntypedString]
+			}
+			if got, ok := foldConstComparison(&gossa.BinOp{
+				Op: token.EQL,
+				X:  gossa.NewConst(tt.x, typ),
+				Y:  gossa.NewConst(tt.y, typ),
+			}); !ok || got {
+				t.Fatalf("foldConstComparison(%s equality) = %v, %v; want false, true", tt.name, got, ok)
+			}
+		})
+	}
 }
 
-func TestCompileFoldsConstStringComparison(t *testing.T) {
+func TestCompileFoldsConstComparisons(t *testing.T) {
 	_, mod := mustCompileLLPkgFromSrc(t, `
 package foo
 
-func equal() bool { return "a" == "b" }
-func less() bool  { return "a" < "b" }
+func intEqual() bool     { return 0 == 1 }
+func stringEqual() bool  { return "a" == "b" }
+func runeEqual() bool    { return '☃' == '☀' }
+func floatEqual() bool   { return 0.0 == 1.0 }
+func complexEqual() bool { return 1i == -1i }
+func stringLess() bool   { return "a" < "b" }
 `)
 	ir := mod.String()
 	if strings.Contains(ir, "StringEqual") {
 		t.Fatalf("constant string comparison called the runtime helper:\n%s", ir)
 	}
-	if !strings.Contains(ir, "ret i1 false") || !strings.Contains(ir, "ret i1 true") {
-		t.Fatalf("constant string comparisons were not folded:\n%s", ir)
+	for _, name := range []string{"intEqual", "stringEqual", "runeEqual", "floatEqual", "complexEqual"} {
+		fn := llvmFunction(t, ir, "foo."+name)
+		if !strings.Contains(fn, "ret i1 false") {
+			t.Fatalf("%s was not folded to false:\n%s", name, fn)
+		}
+	}
+	if fn := llvmFunction(t, ir, "foo.stringLess"); !strings.Contains(fn, "ret i1 true") {
+		t.Fatalf("stringLess was not folded to true:\n%s", fn)
 	}
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1448,6 +1448,30 @@ func F() {}
 	pkgs[0].LPkg.Prog.Dispose()
 }
 
+func TestDoOptimizesUnreachableBodylessCalls(t *testing.T) {
+	conf := NewDefaultConf(ModeGen)
+	conf.AllowNoBody = true
+	pkgs, err := Do([]string{"./testdata/unreachablebodyless/main.go"}, conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgs) != 1 || pkgs[0].LPkg == nil {
+		t.Fatalf("Do returned packages = %+v, want one compiled package", pkgs)
+	}
+	defer pkgs[0].LPkg.Prog.Dispose()
+	mod := pkgs[0].LPkg.Module()
+	mod.SetDataLayout(pkgs[0].LPkg.Prog.DataLayout())
+	mod.SetTarget(pkgs[0].LPkg.Prog.Target().Spec().Triple)
+	pbo := llvm.NewPassBuilderOptions()
+	defer pbo.Dispose()
+	if err := mod.RunPasses("default<O2>", pkgs[0].LPkg.Prog.TargetMachine(), pbo); err != nil {
+		t.Fatalf("optimize generated module: %v", err)
+	}
+	if ir := mod.String(); strings.Contains(ir, "call void @main.fail") {
+		t.Fatalf("unreachable bodyless call remains after optimization:\n%s", ir)
+	}
+}
+
 func TestDoReportsLocalityDirectiveError(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "invalid_locality.go")
 	if err := os.WriteFile(file, []byte(`package invalidlocality

--- a/internal/build/testdata/unreachablebodyless/main.go
+++ b/internal/build/testdata/unreachablebodyless/main.go
@@ -1,0 +1,66 @@
+package main
+
+func fail()
+
+func init() {
+	if false {
+		fail()
+	}
+	if 0 == 1 {
+		fail()
+	}
+}
+
+func init() {
+	const x = 0
+	switch x {
+	case 1:
+		fail()
+	}
+	switch 1 {
+	case x:
+		fail()
+	}
+	switch {
+	case false:
+		fail()
+	}
+	const a = "a"
+	switch a {
+	case "b":
+		fail()
+	}
+	const snowman = '☃'
+	switch snowman {
+	case '☀':
+		fail()
+	}
+	const zero = float64(0)
+	const one = float64(1)
+	switch one {
+	case -1:
+		fail()
+	case zero:
+		fail()
+	}
+	switch 1i {
+	case 1:
+		fail()
+	case -1i:
+		fail()
+	}
+	const no = false
+	switch no {
+	case true:
+		fail()
+	}
+	switch 5 {
+	case 3, 4, 5, 6, 7:
+	case 0, 1, 2:
+		fail()
+	default:
+		fail()
+	}
+}
+
+func main() {}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3023,10 +3023,6 @@ xfails:
     reason: llgo initializes independent imported packages in reverse source order
   - version: go1.26
     directive: rundir
-    case: fixedbugs/issue9608.go
-    reason: llgo does not eliminate unreachable references to a bodyless function before linking
-  - version: go1.26
-    directive: rundir
     case: fixedbugs/issue24693.go
     reason: llgo constructs cross-package itabs incorrectly for unexported interface methods
   - version: go1.26


### PR DESCRIPTION
## Summary

- fold SSA comparisons whose operands are both Go constants before LLVM lowering
- preserve nil and non-constant comparisons on the existing lowering path
- add the fixedbugs/issue9608 counterexample and remove its Go 1.26 xfail

This keeps the fix generic: constant string comparisons no longer become runtime StringEqual calls, so ordinary LLVM optimization can eliminate their unreachable branches and bodyless references.

## Testing

- go test ./cl -run "^(TestFoldConstComparison|TestCompileFoldsConstStringComparison|TestCompileNilBinOpAndHelpers|TestCompileGenericNilSwitchAndCompare)$" -count=1
- go test ./internal/build -run "^(TestDoAllowsMissingFunctionBodies|TestDoOptimizesUnreachableBodylessCalls)$" -count=1
- fixedbugs/issue9608.go with an empty xfail list on Go 1.24.11, Go 1.25.0, and Go 1.26.5
- targeted cl coverage: foldConstComparison 100%
- go test ./test/goroot -count=1

A combined full cl/internal/build run reached the standard 10-minute package timeout while still progressing through unrelated generated-program and PCLN integration cases; no related assertion failure was observed.