### PR TITLE
test/goroot: separate not-applicable cases

### DIFF
--- a/test/goroot/README.md
+++ b/test/goroot/README.md
@@ -18,7 +18,12 @@ Directive modes:
 `coverage` follows the upstream test runner's directive and compiler flag
 conventions. Compile-only and diagnostic cases are executed, not omitted from
 the coverage total. Known failures remain executed and are classified through
-`xfail.yaml`; only explicitly host-unsafe cases are skipped.
+`xfail.yaml`. Cases that exercise gc-specific or otherwise inapplicable
+behavior are classified separately through `notapplicable.yaml`, so the xfail
+count continues to represent remaining LLGo compatibility work. Only
+explicitly host-unsafe cases are skipped. Each not-applicable entry documents
+both the toolchain-specific mechanism under test and why the corresponding
+behavior is not an LLGo compatibility goal.
 
 Basic usage:
 
@@ -76,3 +81,4 @@ Useful flags:
 - `-min-swap-free-mib`: minimum free swap in MiB
 - `-memory-pressure-poll`: system memory and swap sampling interval
 - `-xfail`: xfail YAML file, relative to repo root by default
+- `-not-applicable`: not-applicable YAML file, relative to repo root by default

--- a/test/goroot/notapplicable.yaml
+++ b/test/goroot/notapplicable.yaml
@@ -1,0 +1,501 @@
+# GOROOT cases that validate gc-specific implementation details or other behavior
+# outside LLGo compatibility goals. They still run, but their failures are not
+# counted as remaining compatibility xfails. Every entry names the mechanism
+# under test and explains the LLGo design choice that puts it out of scope.
+not_applicable:
+  - version: go1.26
+    directive: errorcheck
+    case: escape_array.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_struct_param2.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: nilptr3.go
+    reason: "not applicable: this case asserts cmd/compile-specific nil-check elimination diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape6.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_struct_param1.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: nilcheck.go
+    reason: "not applicable: this case asserts cmd/compile-specific nil-check elimination diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue18331.go
+    reason: "not applicable: this case validates a gc-only standard-library pragma; LLGo does not use that cmd/compile pragma pipeline; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue41635.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue52193.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape5.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_slice.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: interface/assertinline.go
+    reason: "not applicable: this case asserts cmd/compile-specific type-assertion optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape4.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_selfassign.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue14999.go
+    reason: "not applicable: this case asserts gc runtime heap-allocation diagnostics; LLGo uses its own runtime and does not expose gc's private compiler diagnostics; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue27732a.go
+    reason: "not applicable: this case asserts cmd/compile-specific small-frame and optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape2n.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_runtime_atomic.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: abi/result_live.go
+    reason: "not applicable: this case asserts cmd/compile-specific liveness diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue21709.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue23521.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue18419.dir/test.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug388.go
+    reason: "not applicable: this case asserts gc runtime pseudo-type diagnostics; LLGo uses its own runtime and does not expose gc's private compiler diagnostics; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape2.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_reflect.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: sliceopt.go
+    reason: "not applicable: this case asserts cmd/compile-specific append and slice optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: writebarrier.go
+    reason: "not applicable: this case validates gc write-barrier insertion and elimination diagnostics; LLGo's BDWGC and tinygogc runtimes do not use Go GC write barriers, so reproducing those diagnostics is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue19743.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue27557.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue10700.dir/test.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_param.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue31573.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue4099.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue7921.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/notinheap3.go
+    reason: "not applicable: this case validates gc write-barrier elimination for cgo.Incomplete-based notinheap values; LLGo's runtimes do not use Go GC write barriers, so this gc heap optimization has no LLGo counterpart and is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_mutations.go
+    reason: "not applicable: this case asserts cmd/compile-specific escape-mutation and zerocopy diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/notinheap2.go
+    reason: "not applicable: this case asserts cmd/compile-specific notinheap allocation diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_map.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: runtime.go
+    reason: "not applicable: this case asserts gc runtime private-symbol compiler diagnostics; LLGo uses its own runtime and does not expose gc's private compiler diagnostics; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/notinheap.go
+    reason: "not applicable: this case asserts cmd/compile-specific notinheap allocation diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_make_non_const.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fuse.go
+    reason: "not applicable: this case asserts gc SSA late-fuse diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue17318.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue30898.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue39292.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue67329.go
+    reason: "not applicable: this case asserts cmd/compile-specific bounds-check elimination diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: devirtualization_with_type_assertions_interleaved.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m devirtualization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_level.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue12588.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20780.go
+    reason: "not applicable: this case asserts cmd/compile-specific stack-frame size diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: bounds.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m bounds-check diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: devirtualization.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m devirtualization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_indir.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: live_uintptrkeepalive.go
+    reason: "not applicable: this case asserts cmd/compile-specific liveness and standard-package diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: uintptrescapes2.go
+    reason: "not applicable: this case asserts cmd/compile-specific escape and liveness diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue19168.go
+    reason: "not applicable: this case validates gc write-barrier recognition for reflect header pointer stores; LLGo's BDWGC and tinygogc runtimes do not use Go GC write barriers, so reproducing those diagnostics is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue75278.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: typeparam/pragma.go
+    reason: "not applicable: this case asserts cmd/compile-specific pragma optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: devirt.go
+    reason: "not applicable: this case asserts gc SSA devirtualization diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_iface_data.go
+    reason: "not applicable: this case asserts cmd/compile-specific escape-debug diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: live2.go
+    reason: "not applicable: this case asserts cmd/compile -live reports while disabling its write-barrier pass; LLGo delegates stack liveness to its LLVM backend and does not expose gc liveness reports, so matching them is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue12006.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue42944.go
+    reason: "not applicable: this case asserts cmd/compile-specific liveness diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: bloop.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: defererrcheck.go
+    reason: "not applicable: this case asserts cmd/compile-specific defer optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_iface.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: prove_popcount.go
+    reason: "not applicable: this case asserts gc SSA prove diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: typeparam/issue54497.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_hash_maphash.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: prove_invert_loop_with_unused_iterators.go
+    reason: "not applicable: this case asserts gc SSA prove diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13799.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue24651b.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_goto.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: prove_constant_folding.go
+    reason: "not applicable: this case asserts gc SSA prove diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue16241_64.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20250.go
+    reason: "not applicable: this case asserts cmd/compile-specific liveness diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue35518.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_field.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_unsafe.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: intrinsic_atomic.go
+    reason: "not applicable: this case asserts cmd/compile-specific intrinsic substitution diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: prove.go
+    reason: "not applicable: this case asserts gc SSA prove diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13587.go
+    reason: "not applicable: this case validates gc write-barrier insertion for implicit stores to escaped result parameters; LLGo's BDWGC and tinygogc runtimes do not use Go GC write barriers, so reproducing that diagnostic is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue16241.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_closure.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_unique.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: inline_variadic.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m inlining diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: phiopt.go
+    reason: "not applicable: this case asserts gc SSA phi optimization diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: tighten.go
+    reason: "not applicable: this case asserts gc SSA tighten diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue35073b.go
+    reason: "not applicable: this case asserts cmd/compile-specific escape and checkptr diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue54159.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: internal/runtime/sys/inlinegcpc.go
+    reason: "not applicable: this case asserts gc runtime inlining diagnostics; LLGo uses its own runtime and does not expose gc's private compiler diagnostics; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_calls.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_sync_atomic.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: inline_sync.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m inlining diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: nowritebarrier.go
+    reason: "not applicable: this case validates gc runtime's private go:nowritebarrier directives; LLGo's BDWGC and tinygogc runtimes do not use Go GC write barriers or those runtime-only pragmas, so supporting them is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: tailcall.go
+    reason: "not applicable: this case asserts cmd/compile-specific tail-call optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue15747.go
+    reason: "not applicable: this case asserts cmd/compile-specific liveness diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue34723.go
+    reason: "not applicable: this case validates gc write-barrier elimination for stores into newly allocated zeroed objects; LLGo's BDWGC and tinygogc runtimes do not use Go GC write barriers, so reproducing that diagnostic is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_bloop.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: escape_struct_return.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: inline_big.go
+    reason: "not applicable: this case asserts cmd/compile-specific -m inlining diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheck
+    case: nilptr5.go
+    reason: "not applicable: this case asserts cmd/compile-specific -d=nil optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: compile
+    case: typeparam/issue50993.go
+    reason: "not applicable: -d=checkptr is a cmd/compile backend debug option, not a Go language requirement; LLGo does not reproduce gc backend flags; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue26163.go
+    reason: "not applicable: -d=softfloat controls cmd/compile target lowering; LLGo delegates floating-point lowering to LLVM; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue56141.go
+    reason: "not applicable: -d=libfuzzer selects cmd/compile instrumentation; LLGo relies on LLVM tooling rather than gc's libfuzzer backend mode; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue56105.go
+    reason: "not applicable: -d=libfuzzer selects cmd/compile instrumentation; LLGo relies on LLVM tooling rather than gc's libfuzzer backend mode; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue34966.go
+    reason: "not applicable: -d=checkptr is a cmd/compile backend debug option, not a Go language requirement; LLGo does not reproduce gc backend flags; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue58826.go
+    reason: "not applicable: -dynlink is a cmd/compile backend mode; LLGo uses the LLVM and native linker pipeline instead; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue69825.go
+    reason: "not applicable: -d=libfuzzer selects cmd/compile instrumentation; LLGo relies on LLVM tooling rather than gc's libfuzzer backend mode; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.24
+    platform: linux/amd64
+    directive: run
+    case: maymorestack.go
+    reason: "not applicable: LLGo uses fixed native stacks, so gc's growable-stack maymorestack debug hook has no corresponding behavior; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.25
+    platform: linux/amd64
+    directive: run
+    case: maymorestack.go
+    reason: "not applicable: LLGo uses fixed native stacks, so gc's growable-stack maymorestack debug hook has no corresponding behavior; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    platform: linux/amd64
+    directive: run
+    case: maymorestack.go
+    reason: "not applicable: LLGo uses fixed native stacks, so gc's growable-stack maymorestack debug hook has no corresponding behavior; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: maymorestack.go
+    reason: "not applicable: LLGo uses fixed native stacks, so gc's growable-stack maymorestack debug hook has no corresponding behavior; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: maymorestack.go
+    reason: "not applicable: LLGo uses fixed native stacks, so gc's growable-stack maymorestack debug hook has no corresponding behavior; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    platform: darwin/arm64
+    directive: run
+    case: maymorestack.go
+    reason: "not applicable: LLGo uses fixed native stacks, so gc's growable-stack maymorestack debug hook has no corresponding behavior; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheckandrundir
+    case: intrinsic.go
+    reason: "not applicable: this case asserts gc SSA intrinsic diagnostics; LLGo uses LLVM's optimization pipeline instead of gc SSA; the language-level run stage remains covered separately; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheckandrundir
+    case: closure3.go
+    reason: "not applicable: this case asserts cmd/compile-specific escape and inlining diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; the language-level run stage remains covered separately; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheckandrundir
+    case: linkname.go
+    reason: "not applicable: this case asserts cmd/compile-specific escape and inlining diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; the language-level run stage remains covered separately; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: errorcheckandrundir
+    case: fixedbugs/issue37837.go
+    reason: "not applicable: this case asserts cmd/compile-specific escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; the language-level run stage remains covered separately; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    platform: darwin/arm64
+    directive: buildrundir
+    case: asmhdr.go
+    reason: "not applicable: LLGo uses LLVM and C toolchains, so the Go assembler asmhdr and symabis pipeline is outside its supported build path; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    directive: runindir
+    case: fixedbugs/issue20014.go
+    reason: "not applicable: fieldtrack is private cmd/compile and cmd/link metadata; LLGo's LLVM and native linker pipeline does not consume it; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
+  - version: go1.26
+    platform: darwin/arm64
+    directive: buildrundir
+    case: retjmp.go
+    reason: "not applicable: LLGo does not accept Go assembler, so its return-jump ABI is outside the supported build path; supporting this toolchain-specific behavior is not an LLGo compatibility goal"

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -33,31 +33,32 @@ import (
 )
 
 var (
-	flagGOROOT     = flag.String("goroot", os.Getenv("LLGO_GOROOT"), "Go toolchain root whose GOROOT/test sources should be used")
-	flagGoCmd      = flag.String("go", os.Getenv("LLGO_GO"), "go binary used as baseline (default: <goroot>/bin/go)")
-	flagLLGO       = flag.String("llgo", os.Getenv("LLGO_TEST_LLGO"), "llgo binary used for comparisons (default: build from current checkout)")
-	flagDirs       = flag.String("dirs", strings.Join(defaultGoRootTestDirs, ","), "comma-separated GOROOT/test subdirectories to scan")
-	flagCase       = flag.String("case", os.Getenv("LLGO_GOROOT_CASE"), "regexp selecting cases by relative path")
-	flagLimit      = flag.Int("limit", 0, "maximum number of matching cases to run")
-	flagShardI     = flag.Int("shard-index", 0, "0-based shard index used to partition matching cases")
-	flagShardN     = flag.Int("shard-total", 1, "number of shards used to partition matching cases")
-	flagKeep       = flag.Bool("keepwork", false, "keep temporary work directories for debugging")
-	flagDirMode    = flag.String("directive-mode", "legacy", "case discovery mode: legacy, ci, runlike, or coverage")
-	flagDirective  = flag.String("directives", "", "comma-separated directive filter within the selected mode")
-	flagXFail      = flag.String("xfail", filepath.Join("test", "goroot", "xfail.yaml"), "xfail configuration path relative to repo root")
-	flagBuildTO    = flag.Duration("build-timeout", 3*time.Minute, "timeout for each go/llgo build step; 0 disables the timeout")
-	flagRunTO      = flag.Duration("run-timeout", time.Minute, "timeout for the compiled program run step; 0 disables the timeout")
-	flagSlowBld    = flag.Duration("slow-build", 10*time.Second, "log build steps that exceed this duration; 0 disables slow-build logging")
-	flagSlowRun    = flag.Duration("slow-run", 5*time.Second, "log run steps that exceed this duration; 0 disables slow-run logging")
-	flagProgress   = flag.Duration("progress", 0, "log current GOROOT case progress at this interval; 0 disables progress logging")
-	flagListCases  = flag.Bool("list-cases", false, "list selected case counts without building or running llgo")
-	flagListPaths  = flag.Bool("list-case-paths", false, "list selected directive and case paths without building or running llgo")
-	flagMaxRSSMiB  = flag.Int64("max-rss-mib", 4096, "maximum RSS in MiB for each spawned process group; 0 disables the limit")
-	flagRSSWarnMiB = flag.Int64("rss-warn-mib", 1024, "log commands whose observed peak process-group RSS reaches this value; 0 disables warnings")
-	flagRSSPoll    = flag.Duration("rss-poll", 100*time.Millisecond, "process-group RSS sampling interval")
-	flagMinMemPct  = flag.Int("min-memory-free-percent", 15, "minimum system-wide free memory percentage required to start and continue a command; 0 disables the check")
-	flagMinSwapMiB = flag.Int64("min-swap-free-mib", 512, "minimum free swap in MiB required to start and continue a command; 0 disables the check")
-	flagMemPoll    = flag.Duration("memory-pressure-poll", time.Second, "system memory pressure sampling interval")
+	flagGOROOT        = flag.String("goroot", os.Getenv("LLGO_GOROOT"), "Go toolchain root whose GOROOT/test sources should be used")
+	flagGoCmd         = flag.String("go", os.Getenv("LLGO_GO"), "go binary used as baseline (default: <goroot>/bin/go)")
+	flagLLGO          = flag.String("llgo", os.Getenv("LLGO_TEST_LLGO"), "llgo binary used for comparisons (default: build from current checkout)")
+	flagDirs          = flag.String("dirs", strings.Join(defaultGoRootTestDirs, ","), "comma-separated GOROOT/test subdirectories to scan")
+	flagCase          = flag.String("case", os.Getenv("LLGO_GOROOT_CASE"), "regexp selecting cases by relative path")
+	flagLimit         = flag.Int("limit", 0, "maximum number of matching cases to run")
+	flagShardI        = flag.Int("shard-index", 0, "0-based shard index used to partition matching cases")
+	flagShardN        = flag.Int("shard-total", 1, "number of shards used to partition matching cases")
+	flagKeep          = flag.Bool("keepwork", false, "keep temporary work directories for debugging")
+	flagDirMode       = flag.String("directive-mode", "legacy", "case discovery mode: legacy, ci, runlike, or coverage")
+	flagDirective     = flag.String("directives", "", "comma-separated directive filter within the selected mode")
+	flagXFail         = flag.String("xfail", filepath.Join("test", "goroot", "xfail.yaml"), "xfail configuration path relative to repo root")
+	flagNotApplicable = flag.String("not-applicable", filepath.Join("test", "goroot", "notapplicable.yaml"), "not-applicable configuration path relative to repo root")
+	flagBuildTO       = flag.Duration("build-timeout", 3*time.Minute, "timeout for each go/llgo build step; 0 disables the timeout")
+	flagRunTO         = flag.Duration("run-timeout", time.Minute, "timeout for the compiled program run step; 0 disables the timeout")
+	flagSlowBld       = flag.Duration("slow-build", 10*time.Second, "log build steps that exceed this duration; 0 disables slow-build logging")
+	flagSlowRun       = flag.Duration("slow-run", 5*time.Second, "log run steps that exceed this duration; 0 disables slow-run logging")
+	flagProgress      = flag.Duration("progress", 0, "log current GOROOT case progress at this interval; 0 disables progress logging")
+	flagListCases     = flag.Bool("list-cases", false, "list selected case counts without building or running llgo")
+	flagListPaths     = flag.Bool("list-case-paths", false, "list selected directive and case paths without building or running llgo")
+	flagMaxRSSMiB     = flag.Int64("max-rss-mib", 4096, "maximum RSS in MiB for each spawned process group; 0 disables the limit")
+	flagRSSWarnMiB    = flag.Int64("rss-warn-mib", 1024, "log commands whose observed peak process-group RSS reaches this value; 0 disables warnings")
+	flagRSSPoll       = flag.Duration("rss-poll", 100*time.Millisecond, "process-group RSS sampling interval")
+	flagMinMemPct     = flag.Int("min-memory-free-percent", 15, "minimum system-wide free memory percentage required to start and continue a command; 0 disables the check")
+	flagMinSwapMiB    = flag.Int64("min-swap-free-mib", 512, "minimum free swap in MiB required to start and continue a command; 0 disables the check")
+	flagMemPoll       = flag.Duration("memory-pressure-poll", time.Second, "system memory pressure sampling interval")
 )
 
 var defaultGoRootTestDirs = []string{
@@ -97,6 +98,10 @@ type xfailConfig struct {
 	Flakes    []xfailEntry   `yaml:"flakes"`
 	HostSkips []xfailEntry   `yaml:"host_skips"`
 	Timeouts  []timeoutEntry `yaml:"timeouts"`
+}
+
+type notApplicableConfig struct {
+	Entries []xfailEntry `yaml:"not_applicable"`
 }
 
 type xfailEntry struct {
@@ -282,6 +287,7 @@ func TestGoRootRunCases(t *testing.T) {
 	}
 
 	xfails := loadXFailConfig(t, repoRoot, *flagXFail)
+	notApplicable := loadNotApplicableConfig(t, repoRoot, *flagNotApplicable)
 	caseFilter := compileCaseFilter(t, *flagCase)
 	mode := loadDirectiveMode(t, *flagDirMode)
 	mode = filterDirectiveMode(t, mode, *flagDirective)
@@ -345,13 +351,21 @@ func TestGoRootRunCases(t *testing.T) {
 			}
 			match, reason := xfails.Match(envInfo.GOVERSION, envInfo.GOOS+"/"+envInfo.GOARCH, tc)
 			flaky, flakyReason := xfails.MatchFlaky(envInfo.GOVERSION, envInfo.GOOS+"/"+envInfo.GOARCH, tc)
+			notApply, notApplyReason := notApplicable.Match(envInfo.GOVERSION, envInfo.GOOS+"/"+envInfo.GOARCH, tc)
+			if match && notApply {
+				t.Fatalf("case matches both xfail and not-applicable expectations: xfail=%s; not applicable=%s", reason, notApplyReason)
+			}
 			switch {
+			case err == nil && notApply:
+				t.Fatalf("unexpected success for not-applicable case: %s", notApplyReason)
 			case err == nil && match:
 				t.Fatalf("unexpected success for xfail case: %s", reason)
 			case err == nil && flaky:
 				t.Logf("flaky case passed: %s", flakyReason)
 			case err != nil && match:
 				t.Logf("expected failure: %s", reason)
+			case err != nil && notApply:
+				t.Logf("expected not-applicable failure: %s", notApplyReason)
 			case err != nil && flaky:
 				t.Logf("known flaky failure: %s", flakyReason)
 			case err != nil:
@@ -431,22 +445,34 @@ func buildLLGOBinary(t *testing.T, repoRoot, goCmd string) string {
 
 func loadXFailConfig(t *testing.T, repoRoot, relPath string) xfailConfig {
 	t.Helper()
+	var cfg xfailConfig
+	loadExpectationConfig(t, repoRoot, relPath, &cfg)
+	return cfg
+}
+
+func loadNotApplicableConfig(t *testing.T, repoRoot, relPath string) notApplicableConfig {
+	t.Helper()
+	var cfg notApplicableConfig
+	loadExpectationConfig(t, repoRoot, relPath, &cfg)
+	return cfg
+}
+
+func loadExpectationConfig(t *testing.T, repoRoot, relPath string, cfg any) {
+	t.Helper()
 	path := relPath
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(repoRoot, relPath)
 	}
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return xfailConfig{}
+		return
 	}
 	if err != nil {
-		t.Fatalf("read xfail file %q: %v", path, err)
+		t.Fatalf("read expectation file %q: %v", path, err)
 	}
-	var cfg xfailConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("parse xfail file %q: %v", path, err)
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		t.Fatalf("parse expectation file %q: %v", path, err)
 	}
-	return cfg
 }
 
 func compileCaseFilter(t *testing.T, expr string) *regexp.Regexp {
@@ -2036,6 +2062,10 @@ func parseGoVersion(goVersion string) (int, int, bool) {
 }
 
 func (cfg xfailConfig) Match(goVersion, platform string, tc testCase) (bool, string) {
+	return matchEntries(cfg.Entries, goVersion, platform, tc)
+}
+
+func (cfg notApplicableConfig) Match(goVersion, platform string, tc testCase) (bool, string) {
 	return matchEntries(cfg.Entries, goVersion, platform, tc)
 }
 

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -102,6 +102,63 @@ func TestXFailMatch(t *testing.T) {
 	}
 }
 
+func TestNotApplicableMatch(t *testing.T) {
+	cfg := notApplicableConfig{
+		Entries: []xfailEntry{{
+			Version:   "go1.26",
+			Directive: "errorcheck",
+			Case:      "writebarrier.go",
+			Reason:    "not applicable: this case checks gc write barriers; LLGo uses a collector without those barriers, so reproducing them is not an LLGo compatibility goal",
+		}},
+	}
+	tc := testCase{RelPath: "writebarrier.go", Directive: "errorcheck"}
+	match, reason := cfg.Match("go1.26.5", "linux/amd64", tc)
+	if !match {
+		t.Fatal("expected not-applicable match")
+	}
+	if reason != "not applicable: this case checks gc write barriers; LLGo uses a collector without those barriers, so reproducing them is not an LLGo compatibility goal" {
+		t.Fatalf("reason=%q, want not-applicable reason", reason)
+	}
+}
+
+func TestRepositoryExpectationsAreSeparated(t *testing.T) {
+	repo := repoRoot(t)
+	xfails := loadXFailConfig(t, repo, filepath.Join("test", "goroot", "xfail.yaml"))
+	notApplicable := loadNotApplicableConfig(t, repo, filepath.Join("test", "goroot", "notapplicable.yaml"))
+	if len(notApplicable.Entries) == 0 {
+		t.Fatal("not-applicable expectation file is empty")
+	}
+
+	type selector struct {
+		version   string
+		platform  string
+		directive string
+		casePath  string
+	}
+	xfailSelectors := make(map[selector]struct{}, len(xfails.Entries))
+	for _, entry := range xfails.Entries {
+		if strings.HasPrefix(entry.Reason, "not applicable:") {
+			t.Fatalf("xfail entry %q has a not-applicable reason", entry.Case)
+		}
+		xfailSelectors[selector{entry.Version, entry.Platform, entry.Directive, entry.Case}] = struct{}{}
+	}
+	for _, entry := range notApplicable.Entries {
+		if !strings.HasPrefix(entry.Reason, "not applicable:") {
+			t.Fatalf("not-applicable entry %q has reason %q without the shared prefix", entry.Case, entry.Reason)
+		}
+		if !strings.Contains(entry.Reason, "LLGo") {
+			t.Fatalf("not-applicable entry %q has reason %q without the LLGo design rationale", entry.Case, entry.Reason)
+		}
+		if !strings.Contains(entry.Reason, "compatibility goal") {
+			t.Fatalf("not-applicable entry %q has reason %q without explaining why support is not planned", entry.Case, entry.Reason)
+		}
+		key := selector{entry.Version, entry.Platform, entry.Directive, entry.Case}
+		if _, ok := xfailSelectors[key]; ok {
+			t.Fatalf("expectation selector appears in both files: %+v", key)
+		}
+	}
+}
+
 func TestFlakyMatch(t *testing.T) {
 	cfg := xfailConfig{
 		Flakes: []xfailEntry{{

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1820,60 +1820,12 @@ flakes:
 xfails:
   - version: go1.26
     directive: errorcheck
-    case: escape_array.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_struct_param2.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: nilptr3.go
-    reason: gc-specific nil-check elimination diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue23664.go
     reason: llgo parser recovery emits additional malformed-declaration diagnostics
   - version: go1.26
     directive: errorcheck
-    case: escape6.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_struct_param1.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: nilcheck.go
-    reason: gc-specific nil-check elimination diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue18331.go
-    reason: gc standard-library pragma validation is not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue41635.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue52193.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue33386.go
     reason: llgo parser recovery emits additional malformed-go/defer diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: escape5.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_slice.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: interface/assertinline.go
-    reason: gc-specific type-assertion optimization diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/bug349.go
@@ -1888,22 +1840,6 @@ xfails:
     reason: llgo parser recovery emits additional semicolon and else diagnostics
   - version: go1.26
     directive: errorcheck
-    case: escape4.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_selfassign.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue14999.go
-    reason: gc runtime heap-allocation diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue27732a.go
-    reason: gc-specific small-frame and optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/bug274.go
     reason: llgo parser recovery emits additional case and label diagnostics
   - version: go1.26
@@ -1914,34 +1850,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/issue4776.go
     reason: llgo parser uses a different missing-package-clause diagnostic
-  - version: go1.26
-    directive: errorcheck
-    case: escape2n.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_runtime_atomic.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: abi/result_live.go
-    reason: gc-specific liveness diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue21709.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue23521.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue18419.dir/test.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/bug388.go
-    reason: gc runtime pseudo-type diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
     case: switch2.go
@@ -1956,34 +1864,6 @@ xfails:
     reason: llgo parser recovery emits additional semicolon and end-of-file diagnostics
   - version: go1.26
     directive: errorcheck
-    case: escape2.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_reflect.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: sliceopt.go
-    reason: gc-specific append and slice optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: writebarrier.go
-    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue19743.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue27557.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue10700.dir/test.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue13274.go
     reason: llgo parser emits an additional end-of-file diagnostic
   - version: go1.26
@@ -1996,40 +1876,12 @@ xfails:
     reason: llgo parser recovery emits additional semicolon and brace diagnostics
   - version: go1.26
     directive: errorcheck
-    case: escape_param.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue31573.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue4099.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue7921.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/notinheap3.go
-    reason: "not applicable: llgo's runtimes do not use Go GC write barriers; notinheap diagnostics are covered separately"
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue13273.go
     reason: llgo parser and type checker emit additional channel-direction diagnostics
   - version: go1.26
     directive: errorcheck
     case: syntax/semi3.go
     reason: llgo parser recovery emits additional semicolon and end-of-file diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: escape_mutations.go
-    reason: gc-specific escape-mutation and zerocopy diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/notinheap2.go
-    reason: gc-specific notinheap allocation diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue13266.go
@@ -2044,18 +1896,6 @@ xfails:
     reason: llgo parser recovery emits additional semicolon and brace diagnostics
   - version: go1.26
     directive: errorcheck
-    case: escape_map.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: runtime.go
-    reason: gc runtime private-symbol compiler diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/notinheap.go
-    reason: gc-specific notinheap allocation diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue13248.go
     reason: llgo parser recovery emits additional malformed-expression diagnostics
   - version: go1.26
@@ -2068,30 +1908,6 @@ xfails:
     reason: llgo parser recovery emits additional semicolon and end-of-file diagnostics
   - version: go1.26
     directive: errorcheck
-    case: escape_make_non_const.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fuse.go
-    reason: gc-specific SSA late-fuse diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue17318.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue30898.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue39292.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue67329.go
-    reason: gc-specific bounds-check elimination diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue20789.go
     reason: llgo parser does not emit the expected malformed-name diagnostic
   - version: go1.26
@@ -2100,76 +1916,8 @@ xfails:
     reason: llgo parser recovery emits additional invalid-initializer diagnostics
   - version: go1.26
     directive: errorcheck
-    case: devirtualization_with_type_assertions_interleaved.go
-    reason: gc-specific -m devirtualization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_level.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue12588.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue20780.go
-    reason: gc-specific stack-frame size diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: bounds.go
-    reason: gc-specific -m bounds-check diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: devirtualization.go
-    reason: gc-specific -m devirtualization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_indir.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: live_uintptrkeepalive.go
-    reason: gc-specific liveness and standard-package diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: uintptrescapes2.go
-    reason: gc-specific escape and liveness diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue19168.go
-    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue75278.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: typeparam/pragma.go
-    reason: gc-specific pragma optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/bug050.go
     reason: llgo parser emits an additional malformed-declaration diagnostic
-  - version: go1.26
-    directive: errorcheck
-    case: devirt.go
-    reason: gc-specific SSA devirtualization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_iface_data.go
-    reason: gc-specific escape-debug diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: live2.go
-    reason: "not applicable: llgo's runtimes do not use Go GC write barriers; liveness diagnostics require separate compiler support"
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue12006.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue42944.go
-    reason: gc-specific liveness diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
     case: bombad.go
@@ -2188,64 +1936,8 @@ xfails:
     reason: llgo parser recovery emits additional malformed-control-clause diagnostics
   - version: go1.26
     directive: errorcheck
-    case: bloop.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: defererrcheck.go
-    reason: gc-specific defer optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_iface.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: prove_popcount.go
-    reason: gc-specific SSA prove diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: typeparam/issue54497.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: syntax/ddd.go
     reason: llgo parser recovery emits additional malformed-selector diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: escape_hash_maphash.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: prove_invert_loop_with_unused_iterators.go
-    reason: gc-specific SSA prove diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue13799.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue24651b.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_goto.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: prove_constant_folding.go
-    reason: gc-specific SSA prove diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue16241_64.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue20250.go
-    reason: gc-specific liveness diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue35518.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/bug121.go
@@ -2260,64 +1952,8 @@ xfails:
     reason: llgo parser recovery emits additional malformed-channel diagnostics
   - version: go1.26
     directive: errorcheck
-    case: escape_field.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_unsafe.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: intrinsic_atomic.go
-    reason: gc-specific intrinsic substitution diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: prove.go
-    reason: gc-specific SSA prove diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue13587.go
-    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue16241.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue18747.go
     reason: llgo parser recovery emits additional undefined-name diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: escape_closure.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_unique.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: inline_variadic.go
-    reason: gc-specific -m inlining diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: phiopt.go
-    reason: gc-specific SSA phi optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: tighten.go
-    reason: gc-specific SSA tighten diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue35073b.go
-    reason: gc-specific escape and checkptr diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue54159.go
-    reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: internal/runtime/sys/inlinegcpc.go
-    reason: gc runtime inlining diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue11610.go
@@ -2328,84 +1964,12 @@ xfails:
     reason: llgo parser recovery emits additional diagnostics for a malformed argument list
   - version: go1.26
     directive: errorcheck
-    case: escape_calls.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_sync_atomic.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: inline_sync.go
-    reason: gc-specific -m inlining diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: nowritebarrier.go
-    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
-  - version: go1.26
-    directive: errorcheck
-    case: tailcall.go
-    reason: gc-specific tail-call optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue15747.go
-    reason: gc-specific liveness diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue34723.go
-    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
-  - version: go1.26
-    directive: errorcheck
     case: syntax/vareq1.go
     reason: llgo parser recovery emits an additional diagnostic after the expected syntax error
   - version: go1.26
     directive: errorcheck
-    case: escape_bloop.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: escape_struct_return.go
-    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: inline_big.go
-    reason: gc-specific -m inlining diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: nilptr5.go
-    reason: gc-specific -d=nil optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
     case: syntax/vareq.go
     reason: llgo parser recovery emits additional diagnostics after the expected syntax error
-  - version: go1.26
-    directive: compile
-    case: typeparam/issue50993.go
-    reason: gc-specific -d=checkptr backend option is not implemented by llgo
-  - version: go1.26
-    directive: compile
-    case: fixedbugs/issue26163.go
-    reason: gc-specific -d=softfloat backend option is not implemented by llgo
-  - version: go1.26
-    directive: compile
-    case: fixedbugs/issue56141.go
-    reason: gc-specific -d=libfuzzer backend option is not implemented by llgo
-  - version: go1.26
-    directive: compile
-    case: fixedbugs/issue56105.go
-    reason: gc-specific -d=libfuzzer backend option is not implemented by llgo
-  - version: go1.26
-    directive: compile
-    case: fixedbugs/issue34966.go
-    reason: gc-specific -d=checkptr backend option is not implemented by llgo
-  - version: go1.26
-    directive: compile
-    case: fixedbugs/issue58826.go
-    reason: gc-specific -dynlink backend mode is not implemented by llgo
-  - version: go1.26
-    directive: compile
-    case: fixedbugs/issue69825.go
-    reason: gc-specific -d=libfuzzer backend option is not implemented by llgo
   - version: go1.24
     platform: darwin/arm64
     directive: run
@@ -2758,21 +2322,6 @@ xfails:
     directive: run
     case: fixedbugs/issue75327.go
     reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: maymorestack.go
-    reason: go1.24 goroot ci-mode run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: maymorestack.go
-    reason: go1.25 goroot ci-mode run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: maymorestack.go
-    reason: go1.26 goroot ci-mode run failure on linux/amd64
   - version: go1.24
     platform: linux/amd64
     directive: runoutput
@@ -3150,21 +2699,6 @@ xfails:
     directive: run
     case: fixedbugs/issue5493.go
     reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: darwin/arm64
-    directive: run
-    case: maymorestack.go
-    reason: go1.24 goroot ci-mode run failure on darwin/arm64
-  - version: go1.25
-    platform: darwin/arm64
-    directive: run
-    case: maymorestack.go
-    reason: go1.25 goroot ci-mode run failure on darwin/arm64
-  - version: go1.26
-    platform: darwin/arm64
-    directive: run
-    case: maymorestack.go
-    reason: go1.26 goroot ci-mode run failure on darwin/arm64
   - version: go1.26
     platform: linux/amd64
     directive: run
@@ -3483,31 +3017,10 @@ xfails:
     case: index0.go
     reason: current main goroot runoutput failure on linux/amd64
   - version: go1.26
-    directive: errorcheckandrundir
-    case: intrinsic.go
-    reason: gc-specific SSA intrinsic diagnostics are not implemented by llgo; the run stage still executes
-  - version: go1.26
-    directive: errorcheckandrundir
-    case: closure3.go
-    reason: gc-specific escape and inlining diagnostics are not implemented by llgo; the run stage still executes
-  - version: go1.26
-    directive: errorcheckandrundir
-    case: linkname.go
-    reason: gc-specific escape and inlining diagnostics are not implemented by llgo; the run stage still executes
-  - version: go1.26
-    directive: errorcheckandrundir
-    case: fixedbugs/issue37837.go
-    reason: gc-specific escape-analysis diagnostics are not implemented by llgo; the run stage still executes
-  - version: go1.26
     platform: darwin/arm64
     directive: rundir
     case: fixedbugs/issue29919.go
     reason: runtime CallersFrames reports llgo package names and initialization line metadata differently
-  - version: go1.26
-    platform: darwin/arm64
-    directive: buildrundir
-    case: asmhdr.go
-    reason: llgo build does not implement the Go assembler asmhdr and symabis pipeline
   - version: go1.26
     directive: rundir
     case: fixedbugs/issue31636.go
@@ -3516,15 +3029,6 @@ xfails:
     directive: rundir
     case: fixedbugs/issue9608.go
     reason: llgo does not eliminate unreachable references to a bodyless function before linking
-  - version: go1.26
-    directive: runindir
-    case: fixedbugs/issue20014.go
-    reason: gc-specific fieldtrack linker metadata is not implemented by llgo
-  - version: go1.26
-    platform: darwin/arm64
-    directive: buildrundir
-    case: retjmp.go
-    reason: llgo does not preserve Go assembler return-jump ABI behavior
   - version: go1.26
     directive: rundir
     case: fixedbugs/issue24693.go


### PR DESCRIPTION
## Summary

- teach the GOROOT runner to read a separate `test/goroot/notapplicable.yaml` file
- keep not-applicable cases executing, while treating both unexpected success and overlap with `xfail.yaml` as stale configuration errors
- move 122 gc/toolchain-specific cases out of `xfail.yaml`, leaving 262 actionable compatibility xfails
- require every not-applicable entry to name the mechanism under test, explain the relevant LLGo architecture choice, and state why support is not an LLGo compatibility goal
- document the split and the new `-not-applicable` runner flag

This changes only the GOROOT runner and its expectation data; it does not change compiler, runtime, or CI behavior.

## Audit

The selector inventory is conserved exactly: the previous 384 xfails are now 262 actionable xfails plus 122 not-applicable entries, with no duplicate or overlapping selectors. `host_skips`, `timeouts`, and `flakes` are unchanged.

Moved categories are gc-specific diagnostics and backend modes, gc runtime/write-barrier behavior, the `maymorestack` growable-stack hook, fieldtrack metadata, and Go-assembler-only cases. Parser/type-checker diagnostics and language/runtime semantic failures remain in `xfail.yaml`.

## Validation

- `go test ./test/goroot -run "^Test" -skip "^TestGoRootRunCases$" -count=1`
- inventory conservation and unsupported-reason audit: 384 = 262 + 122, zero overlap, zero unsupported-looking reasons left in `xfail.yaml`
- Go 1.26.5 darwin/arm64 GOROOT coverage run for `maymorestack.go`, `live2.go`, `writebarrier.go`, `nowritebarrier.go`, `fixedbugs/notinheap3.go`, and three write-barrier fixedbugs cases