### PR TITLE
test/goroot: remove stale bug388 expectation

### DIFF
--- a/test/goroot/notapplicable.yaml
+++ b/test/goroot/notapplicable.yaml
@@ -93,10 +93,6 @@ not_applicable:
     reason: "not applicable: this case asserts cmd/compile-specific -m optimization diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/bug388.go
-    reason: "not applicable: this case asserts gc runtime pseudo-type diagnostics; LLGo uses its own runtime and does not expose gc's private compiler diagnostics; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
-  - version: go1.26
-    directive: errorcheck
     case: escape2.go
     reason: "not applicable: this case asserts cmd/compile-specific -m escape-analysis diagnostics; LLGo uses go/types plus LLVM and does not reproduce gc compiler diagnostic output; supporting this toolchain-specific behavior is not an LLGo compatibility goal"
   - version: go1.26


### PR DESCRIPTION
Removes the stale Go 1.26 not-applicable entry for `fixedbugs/bug388.go` after #2274 made cmd/compile syntax diagnostics authoritative.

The implementation includes:

- Removes `fixedbugs/bug388.go` from `test/goroot/notapplicable.yaml`.
- Relies on the loader behavior merged in #2274 and introduces no production code changes.
- Verifies the case with the Go 1.26.5 GOROOT errorcheck runner and the expectation configuration tests.

This keeps the GOROOT expectations aligned with current LLGo behavior and prevents a passing case from being reported as an unexpected success.