### PR TITLE
ci: publish benchmarks in repository Pages

### DIFF
--- a/.github/llgo-benchmark.yml
+++ b/.github/llgo-benchmark.yml
@@ -1,7 +1,7 @@
 version: 1
 id: llgo-baseline
 title: LLGo baseline benchmarks
-site-path: llgo/baseline
+site-path: benchmark/baseline
 include:
   - "^BenchmarkProgram/"
   - "^Benchmark(MergeCompilerFlags|MergeLinkerFlags|LookupPCRandom)$"

--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -18,9 +18,3 @@ jobs:
     with:
       run_id: ${{ github.event.workflow_run.id }}
       config_path: .github/llgo-benchmark.yml
-      data_repository: >-
-        ${{ vars.BENCHMARKS_REPOSITORY ||
-            format('{0}/llgo-benchmark-data', github.repository_owner) }}
-      data_dispatch_event: llgo-baseline-published
-    secrets:
-      data_token: ${{ secrets.BENCHMARK_DATA_TOKEN }}


### PR DESCRIPTION
## Summary

- publish benchmark history to the repository `pages` branch without a separate data repository or dispatch token
- namespace the site output at `benchmark/baseline` to avoid collisions with other Pages content

This ports the two commits from cpunion/llgo#141. The cpunion source PR is merged and its source branch has been deleted; this PR is the xgo-dev counterpart.

## Validation

- YAML parsing passes for `.github/workflows/benchmark-publish.yml` and `.github/llgo-benchmark.yml`
- `git diff --check` passes
- only the benchmark publisher workflow and benchmark site path change
