### PR TITLE
ci: compare benchmarks on the same runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,6 +32,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Check out pull request base
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.base.repo.full_name }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .benchmark/base-source
+          persist-credentials: false
+
       - name: Install dependencies
         uses: ./.github/actions/setup-deps
         with:
@@ -40,63 +49,28 @@ jobs:
       - name: Set up Go
         uses: ./.github/actions/setup-go
 
-      - name: Build LLGo
+      - name: Measure pull request base
+        if: github.event_name == 'pull_request'
         run: |
-          set -euo pipefail
-          mkdir -p .benchmark
-          go build -p=1 -o .benchmark/llgo ./cmd/llgo
+          benchmark/baseline/run.sh \
+            "$GITHUB_WORKSPACE/.benchmark/base-source" \
+            "$GITHUB_WORKSPACE/.benchmark/base-llgo" \
+            "$GITHUB_WORKSPACE/.benchmark/base-results"
 
-      - name: Measure programs
+      - name: Measure current revision
         run: |
-          set -euo pipefail
-          go run ./benchmark/baseline \
-            -llgo "$GITHUB_WORKSPACE/.benchmark/llgo" \
-            -out "$GITHUB_WORKSPACE/.benchmark/results"
-
-      - name: Run selected Go benchmarks
-        run: |
-          set -euo pipefail
-          results="$GITHUB_WORKSPACE/.benchmark/results/go.txt"
-          GOMAXPROCS=1 go test \
-            -run '^$' \
-            -bench '^(BenchmarkMergeCompilerFlags|BenchmarkMergeLinkerFlags|BenchmarkLookupPCRandom)$' \
-            -benchtime=250ms \
-            -count=1 \
-            -cpu=1 \
-            ./internal/clang ./internal/build/funcinfo \
-            | tee "$results"
-
-          GOMAXPROCS=1 "$GITHUB_WORKSPACE/.benchmark/llgo" test \
-            -run '^$' \
-            -bench '^(BenchmarkRuntimeGetG|BenchmarkGlobal(Read|Write)|Benchmark(DirectCall|InterfaceCall|Defer|ChannelBuffered|ChannelHandoff))$' \
-            -benchtime=250ms \
-            -count=1 \
-            ./test/llgoext \
-            | tee -a "$results"
-
-          # The current native backend creates one pthread per goroutine and
-          # intentionally has a bounded lifecycle stress limit. Keep creation
-          # monitoring deterministic instead of letting testing auto-calibrate
-          # to millions of host threads.
-          GOMAXPROCS=1 "$GITHUB_WORKSPACE/.benchmark/llgo" test \
-            -run '^$' \
-            -bench '^BenchmarkGoroutine$' \
-            -benchtime=100x \
-            -count=1 \
-            ./test/llgoext \
-            | tee -a "$results"
-
-      - name: Validate and export benchmark artifact
-        run: |
-          go run ./benchmark/baseline \
-            -mode export \
-            -out .benchmark/results \
-            -benchmark-output .benchmark/results/benchmark.txt
+          benchmark/baseline/run.sh \
+            "$GITHUB_WORKSPACE" \
+            "$GITHUB_WORKSPACE/.benchmark/llgo" \
+            "$GITHUB_WORKSPACE/.benchmark/results"
 
       - name: Record benchmark result
         uses: xgo-dev/setup-benchmark-go-action@v1
         with:
           config: .github/llgo-benchmark.yml
           benchmark-file: .benchmark/results/benchmark.txt
+          baseline-benchmark-file: >-
+            ${{ github.event_name == 'pull_request' &&
+                '.benchmark/base-results/benchmark.txt' || '' }}
           platform-id: ${{ matrix.id }}
           platform-label: ${{ matrix.display }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,13 +32,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Check out pull request base
+      - name: Check out pull request base benchmark source
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.sha }}
-          path: .benchmark/base-source
+          path: .benchmark/source
           persist-credentials: false
 
       - name: Install dependencies
@@ -53,14 +53,27 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           benchmark/baseline/run.sh \
-            "$GITHUB_WORKSPACE/.benchmark/base-source" \
+            "$GITHUB_WORKSPACE/.benchmark/source" \
             "$GITHUB_WORKSPACE/.benchmark/base-llgo" \
             "$GITHUB_WORKSPACE/.benchmark/base-results"
 
+      - name: Check out pull request head benchmark source
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: .benchmark/source
+          persist-credentials: false
+
       - name: Measure current revision
         run: |
+          source_root="$GITHUB_WORKSPACE"
+          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+            source_root="$GITHUB_WORKSPACE/.benchmark/source"
+          fi
           benchmark/baseline/run.sh \
-            "$GITHUB_WORKSPACE" \
+            "$source_root" \
             "$GITHUB_WORKSPACE/.benchmark/llgo" \
             "$GITHUB_WORKSPACE/.benchmark/results"
 

--- a/benchmark/baseline/README.md
+++ b/benchmark/baseline/README.md
@@ -22,10 +22,17 @@ stream adds selected compiler helpers and LLGo-generated core-language
 operations: direct/interface calls, defer, goroutine creation, channels,
 `getg`, and global access.
 
-The trusted publisher compares each platform against the latest matching
-`main` data and commits the history and generated site to the `pages` branch of
-the configured data repository. Every LLGo repository defaults to
-`<owner>/llgo-benchmark-data`:
+For pull requests, each platform job checks out the recorded base commit and
+runs the base and current suites sequentially on the same runner. The pull
+request comment compares that pair, avoiding differences between runner
+machines. Dependency setup is shared, and Go's build cache can be reused by
+unchanged packages; main pushes still run the suite only once. If a workflow
+does not provide a paired result, the publisher falls back to the latest
+matching `main` data.
+
+The trusted publisher commits the current result history and generated site to
+the `pages` branch of the configured data repository. Every LLGo repository
+defaults to `<owner>/llgo-benchmark-data`:
 
 ```text
 llgo/baseline/series/main/main

--- a/benchmark/baseline/README.md
+++ b/benchmark/baseline/README.md
@@ -14,21 +14,23 @@ The program workloads reuse:
 - `benchmark/binary_size/println`: only the built-in `println`;
 - `benchmark/binary_size/fmtprintf`: `fmt.Printf`.
 
-For each workload, the collector records median warm build time, median process
-time, file size, executable-code bytes, allocated non-executable data, and
-zero-filled data. On ELF, read-only constants are included in the data bucket;
-on Mach-O, `__TEXT` constants are included in the text bucket. The Go benchmark
-stream adds selected compiler helpers and LLGo-generated core-language
-operations: direct/interface calls, defer, goroutine creation, channels,
-`getg`, and global access.
+For each workload, the collector performs an unmeasured warm build, then records
+median build time, median process time, file size, executable-code bytes,
+allocated non-executable data, and zero-filled data. On ELF, read-only constants
+are included in the data bucket; on Mach-O, `__TEXT` constants are included in
+the text bucket. The Go benchmark stream records three samples of selected
+compiler helpers and LLGo-generated core-language operations: direct/interface
+calls, defer, goroutine creation, channels, `getg`, and global access.
 
-For pull requests, each platform job checks out the recorded base commit and
-runs the base and current suites sequentially on the same runner. The pull
-request comment compares that pair, avoiding differences between runner
-machines. Dependency setup is shared, and Go's build cache can be reused by
-unchanged packages; main pushes still run the suite only once. If a workflow
-does not provide a paired result, the publisher falls back to the latest
-matching `main` data.
+For pull requests, each platform job checks out the recorded base and current
+commits into the same source path, then runs both suites sequentially on the same
+runner. The pull request comment compares that pair, avoiding differences from
+runner machines and embedded source paths. Dependency setup is shared, and Go's
+build cache can be reused by unchanged packages; main pushes still run the suite
+only once. Very small changes can still be scheduler, frequency, or thermal
+noise and should be confirmed by repeated workflow runs. If a workflow does not
+provide a paired result, the publisher falls back to the latest matching `main`
+data.
 
 The trusted publisher commits the current result history and generated site to
 the `pages` branch of the configured data repository. Every LLGo repository
@@ -62,15 +64,15 @@ results=.benchmark/results/go.txt
 GOMAXPROCS=1 go test \
   -run '^$' \
   -bench '^(BenchmarkMergeCompilerFlags|BenchmarkMergeLinkerFlags|BenchmarkLookupPCRandom)$' \
-  -benchtime=250ms -count=1 -cpu=1 \
+  -benchtime=250ms -count=3 -cpu=1 \
   ./internal/clang ./internal/build/funcinfo | tee "$results"
 GOMAXPROCS=1 .benchmark/llgo test \
   -run '^$' \
   -bench '^(BenchmarkRuntimeGetG|BenchmarkGlobal(Read|Write)|Benchmark(DirectCall|InterfaceCall|Defer|ChannelBuffered|ChannelHandoff))$' \
-  -benchtime=250ms -count=1 \
+  -benchtime=250ms -count=3 \
   ./test/llgoext | tee -a "$results"
 GOMAXPROCS=1 .benchmark/llgo test \
-  -run '^$' -bench '^BenchmarkGoroutine$' -benchtime=100x -count=1 \
+  -run '^$' -bench '^BenchmarkGoroutine$' -benchtime=100x -count=3 \
   ./test/llgoext | tee -a "$results"
 ```
 

--- a/benchmark/baseline/README.md
+++ b/benchmark/baseline/README.md
@@ -18,7 +18,7 @@ For each workload, the collector performs an unmeasured warm build, then records
 median build time, median process time, file size, executable-code bytes,
 allocated non-executable data, and zero-filled data. On ELF, read-only constants
 are included in the data bucket; on Mach-O, `__TEXT` constants are included in
-the text bucket. The Go benchmark stream records three samples of selected
+the text bucket. The Go benchmark stream records five samples of selected
 compiler helpers and LLGo-generated core-language operations: direct/interface
 calls, defer, goroutine creation, channels, `getg`, and global access.
 
@@ -64,15 +64,15 @@ results=.benchmark/results/go.txt
 GOMAXPROCS=1 go test \
   -run '^$' \
   -bench '^(BenchmarkMergeCompilerFlags|BenchmarkMergeLinkerFlags|BenchmarkLookupPCRandom)$' \
-  -benchtime=250ms -count=3 -cpu=1 \
+  -benchtime=250ms -count=5 -cpu=1 \
   ./internal/clang ./internal/build/funcinfo | tee "$results"
 GOMAXPROCS=1 .benchmark/llgo test \
   -run '^$' \
   -bench '^(BenchmarkRuntimeGetG|BenchmarkGlobal(Read|Write)|Benchmark(DirectCall|InterfaceCall|Defer|ChannelBuffered|ChannelHandoff))$' \
-  -benchtime=250ms -count=3 \
+  -benchtime=250ms -count=5 \
   ./test/llgoext | tee -a "$results"
 GOMAXPROCS=1 .benchmark/llgo test \
-  -run '^$' -bench '^BenchmarkGoroutine$' -benchtime=100x -count=3 \
+  -run '^$' -bench '^BenchmarkGoroutine$' -benchtime=100x -count=5 \
   ./test/llgoext | tee -a "$results"
 ```
 

--- a/benchmark/baseline/main.go
+++ b/benchmark/baseline/main.go
@@ -74,6 +74,8 @@ var expectedGoBenchmarks = []string{
 	"BenchmarkRuntimeGetG",
 }
 
+const goBenchmarkSamples = 3
+
 type footprint struct {
 	file uint64
 	text uint64
@@ -221,6 +223,11 @@ func collect(ctx context.Context, root, llgo, out string, buildRuns, runRuns int
 	var sizes, timings []metric
 	for _, item := range workloads {
 		binary := filepath.Join(binDir, item.name)
+		// Keep first-use toolchain and filesystem caches out of the measured
+		// median so the first revision is not systematically disadvantaged.
+		if err := run(ctx, env, io.Discard, llgo, "build", "-o", binary, filepath.Join(root, item.source)); err != nil {
+			return fmt.Errorf("warm build %s: %w", item.name, err)
+		}
 		buildDurations := make([]time.Duration, 0, buildRuns)
 		for range buildRuns {
 			start := time.Now()
@@ -433,9 +440,9 @@ func validateMetrics(path string, expected map[string]string) error {
 }
 
 func validateGoBenchmarks(r io.Reader) error {
-	expected := make(map[string]bool, len(expectedGoBenchmarks))
+	expected := make(map[string]int, len(expectedGoBenchmarks))
 	for _, name := range expectedGoBenchmarks {
-		expected[name] = false
+		expected[name] = 0
 	}
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -444,12 +451,12 @@ func validateGoBenchmarks(r io.Reader) error {
 			continue
 		}
 		name := cpuSuffix.ReplaceAllString(fields[0], "")
-		seen, ok := expected[name]
+		samples, ok := expected[name]
 		if !ok {
 			return fmt.Errorf("unexpected Go benchmark %q", name)
 		}
-		if seen {
-			return fmt.Errorf("duplicate Go benchmark %q", name)
+		if samples >= goBenchmarkSamples {
+			return fmt.Errorf("too many samples for Go benchmark %q", name)
 		}
 		if len(fields) < 4 || (len(fields)-2)%2 != 0 {
 			return fmt.Errorf("malformed Go benchmark line %q", scanner.Text())
@@ -474,20 +481,25 @@ func validateGoBenchmarks(r io.Reader) error {
 		if !hasTime {
 			return fmt.Errorf("benchmark %q has no ns/op result", name)
 		}
-		expected[name] = true
+		expected[name] = samples + 1
 	}
 	if err := scanner.Err(); err != nil {
 		return err
 	}
 	var missing []string
-	for name, seen := range expected {
-		if !seen {
+	for name, samples := range expected {
+		if samples == 0 {
 			missing = append(missing, name)
 		}
 	}
 	slices.Sort(missing)
 	if len(missing) != 0 {
 		return fmt.Errorf("missing Go benchmarks: %s", strings.Join(missing, ", "))
+	}
+	for name, samples := range expected {
+		if samples != goBenchmarkSamples {
+			return fmt.Errorf("Go benchmark %q has %d samples, want %d", name, samples, goBenchmarkSamples)
+		}
 	}
 	return nil
 }

--- a/benchmark/baseline/main.go
+++ b/benchmark/baseline/main.go
@@ -74,7 +74,7 @@ var expectedGoBenchmarks = []string{
 	"BenchmarkRuntimeGetG",
 }
 
-const goBenchmarkSamples = 3
+const goBenchmarkSamples = 5
 
 type footprint struct {
 	file uint64

--- a/benchmark/baseline/main_test.go
+++ b/benchmark/baseline/main_test.go
@@ -23,6 +23,7 @@ import (
 	"debug/macho"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -187,7 +188,7 @@ func TestValidateGoBenchmarksRejectsInvalidData(t *testing.T) {
 		{"missing", valid(expectedGoBenchmarks[0]), "missing Go benchmarks"},
 		{"unknown", valid("") + "BenchmarkUnknown-1 1 1 ns/op\n", `unexpected Go benchmark "BenchmarkUnknown"`},
 		{"too many samples", valid("") + expectedGoBenchmarks[0] + "-1 1 1 ns/op\n", "too many samples"},
-		{"too few samples", strings.Replace(valid(""), expectedGoBenchmarks[0]+"-1 100 12.5 ns/op\n", "", 1), "has 2 samples, want 3"},
+		{"too few samples", strings.Replace(valid(""), expectedGoBenchmarks[0]+"-1 100 12.5 ns/op\n", "", 1), fmt.Sprintf("has %d samples, want %d", goBenchmarkSamples-1, goBenchmarkSamples)},
 		{"malformed", strings.Replace(valid(""), " 100 12.5 ns/op", " bad", 1), "malformed Go benchmark"},
 		{"iterations", strings.Replace(valid(""), " 100 ", " bad ", 1), "invalid iteration count"},
 		{"value", strings.Replace(valid(""), "12.5", "bad", 1), "invalid value"},

--- a/benchmark/baseline/main_test.go
+++ b/benchmark/baseline/main_test.go
@@ -157,8 +157,10 @@ func TestValidateMetricsRejectsInvalidData(t *testing.T) {
 func TestValidateGoBenchmarks(t *testing.T) {
 	var input strings.Builder
 	for _, name := range expectedGoBenchmarks {
-		input.WriteString(name)
-		input.WriteString("-1 100 12.5 ns/op\n")
+		for range goBenchmarkSamples {
+			input.WriteString(name)
+			input.WriteString("-1 100 12.5 ns/op\n")
+		}
 	}
 	if err := validateGoBenchmarks(strings.NewReader(input.String())); err != nil {
 		t.Fatal(err)
@@ -170,7 +172,9 @@ func TestValidateGoBenchmarksRejectsInvalidData(t *testing.T) {
 		var input strings.Builder
 		for _, name := range expectedGoBenchmarks {
 			if name != skip {
-				input.WriteString(name + "-1 100 12.5 ns/op\n")
+				for range goBenchmarkSamples {
+					input.WriteString(name + "-1 100 12.5 ns/op\n")
+				}
 			}
 		}
 		return input.String()
@@ -182,7 +186,8 @@ func TestValidateGoBenchmarksRejectsInvalidData(t *testing.T) {
 	}{
 		{"missing", valid(expectedGoBenchmarks[0]), "missing Go benchmarks"},
 		{"unknown", valid("") + "BenchmarkUnknown-1 1 1 ns/op\n", `unexpected Go benchmark "BenchmarkUnknown"`},
-		{"duplicate", valid("") + expectedGoBenchmarks[0] + "-1 1 1 ns/op\n", "duplicate Go benchmark"},
+		{"too many samples", valid("") + expectedGoBenchmarks[0] + "-1 1 1 ns/op\n", "too many samples"},
+		{"too few samples", strings.Replace(valid(""), expectedGoBenchmarks[0]+"-1 100 12.5 ns/op\n", "", 1), "has 2 samples, want 3"},
 		{"malformed", strings.Replace(valid(""), " 100 12.5 ns/op", " bad", 1), "malformed Go benchmark"},
 		{"iterations", strings.Replace(valid(""), " 100 ", " bad ", 1), "invalid iteration count"},
 		{"value", strings.Replace(valid(""), "12.5", "bad", 1), "invalid value"},
@@ -523,7 +528,9 @@ func writeValidArtifact(t *testing.T, dir string) {
 func makeGoBenchmarkText() string {
 	var input strings.Builder
 	for _, name := range expectedGoBenchmarks {
-		input.WriteString(name + "-1 100 12.5 ns/op\n")
+		for range goBenchmarkSamples {
+			input.WriteString(name + "-1 100 12.5 ns/op\n")
+		}
 	}
 	return input.String()
 }

--- a/benchmark/baseline/run.sh
+++ b/benchmark/baseline/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <source-root> <llgo-output> <result-directory>" >&2
+  exit 2
+fi
+
+source_root="$1"
+llgo_output="$2"
+result_directory="$3"
+harness_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+mkdir -p "$(dirname "$llgo_output")" "$result_directory"
+
+(
+  cd "$source_root"
+  LLGO_ROOT="$source_root" go build -p=1 -o "$llgo_output" ./cmd/llgo
+)
+
+(
+  cd "$harness_root"
+  LLGO_ROOT="$source_root" go run ./benchmark/baseline \
+    -root "$source_root" \
+    -llgo "$llgo_output" \
+    -out "$result_directory"
+)
+
+go_results="$result_directory/go.txt"
+(
+  cd "$source_root"
+  GOMAXPROCS=1 LLGO_ROOT="$source_root" go test \
+    -run '^$' \
+    -bench '^(BenchmarkMergeCompilerFlags|BenchmarkMergeLinkerFlags|BenchmarkLookupPCRandom)$' \
+    -benchtime=250ms \
+    -count=1 \
+    -cpu=1 \
+    ./internal/clang ./internal/build/funcinfo
+) | tee "$go_results"
+
+(
+  cd "$source_root"
+  GOMAXPROCS=1 LLGO_ROOT="$source_root" "$llgo_output" test \
+    -run '^$' \
+    -bench '^(BenchmarkRuntimeGetG|BenchmarkGlobal(Read|Write)|Benchmark(DirectCall|InterfaceCall|Defer|ChannelBuffered|ChannelHandoff))$' \
+    -benchtime=250ms \
+    -count=1 \
+    ./test/llgoext
+) | tee -a "$go_results"
+
+# The current native backend creates one pthread per goroutine and intentionally
+# has a bounded lifecycle stress limit. Keep creation monitoring deterministic
+# instead of letting testing auto-calibrate to millions of host threads.
+(
+  cd "$source_root"
+  GOMAXPROCS=1 LLGO_ROOT="$source_root" "$llgo_output" test \
+    -run '^$' \
+    -bench '^BenchmarkGoroutine$' \
+    -benchtime=100x \
+    -count=1 \
+    ./test/llgoext
+) | tee -a "$go_results"
+
+(
+  cd "$harness_root"
+  go run ./benchmark/baseline \
+    -mode export \
+    -out "$result_directory" \
+    -benchmark-output "$result_directory/benchmark.txt"
+)

--- a/benchmark/baseline/run.sh
+++ b/benchmark/baseline/run.sh
@@ -37,7 +37,7 @@ go_results="$result_directory/go.txt"
     -run '^$' \
     -bench '^(BenchmarkMergeCompilerFlags|BenchmarkMergeLinkerFlags|BenchmarkLookupPCRandom)$' \
     -benchtime=250ms \
-    -count=3 \
+    -count=5 \
     -cpu=1 \
     ./internal/clang ./internal/build/funcinfo
 ) | tee -a "$go_results"
@@ -48,7 +48,7 @@ go_results="$result_directory/go.txt"
     -run '^$' \
     -bench '^(BenchmarkRuntimeGetG|BenchmarkGlobal(Read|Write)|Benchmark(DirectCall|InterfaceCall|Defer|ChannelBuffered|ChannelHandoff))$' \
     -benchtime=250ms \
-    -count=3 \
+    -count=5 \
     ./test/llgoext
 ) | tee -a "$go_results"
 
@@ -61,7 +61,7 @@ go_results="$result_directory/go.txt"
     -run '^$' \
     -bench '^BenchmarkGoroutine$' \
     -benchtime=100x \
-    -count=3 \
+    -count=5 \
     ./test/llgoext
 ) | tee -a "$go_results"
 

--- a/benchmark/baseline/run.sh
+++ b/benchmark/baseline/run.sh
@@ -7,12 +7,12 @@ if [[ $# -ne 3 ]]; then
   exit 2
 fi
 
-source_root="$1"
-llgo_output="$2"
-result_directory="$3"
 harness_root="$(cd "$(dirname "$0")/../.." && pwd)"
 
-mkdir -p "$(dirname "$llgo_output")" "$result_directory"
+source_root="$(cd "$1" && pwd)"
+mkdir -p "$(dirname "$2")" "$3"
+llgo_output="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+result_directory="$(cd "$3" && pwd)"
 
 (
   cd "$source_root"
@@ -21,6 +21,8 @@ mkdir -p "$(dirname "$llgo_output")" "$result_directory"
 
 (
   cd "$harness_root"
+  # Keep one current-checkout harness for both source revisions. Benchmark
+  # suite changes must therefore remain executable against the PR base.
   LLGO_ROOT="$source_root" go run ./benchmark/baseline \
     -root "$source_root" \
     -llgo "$llgo_output" \
@@ -28,16 +30,17 @@ mkdir -p "$(dirname "$llgo_output")" "$result_directory"
 )
 
 go_results="$result_directory/go.txt"
+: > "$go_results"
 (
   cd "$source_root"
   GOMAXPROCS=1 LLGO_ROOT="$source_root" go test \
     -run '^$' \
     -bench '^(BenchmarkMergeCompilerFlags|BenchmarkMergeLinkerFlags|BenchmarkLookupPCRandom)$' \
     -benchtime=250ms \
-    -count=1 \
+    -count=3 \
     -cpu=1 \
     ./internal/clang ./internal/build/funcinfo
-) | tee "$go_results"
+) | tee -a "$go_results"
 
 (
   cd "$source_root"
@@ -45,7 +48,7 @@ go_results="$result_directory/go.txt"
     -run '^$' \
     -bench '^(BenchmarkRuntimeGetG|BenchmarkGlobal(Read|Write)|Benchmark(DirectCall|InterfaceCall|Defer|ChannelBuffered|ChannelHandoff))$' \
     -benchtime=250ms \
-    -count=1 \
+    -count=3 \
     ./test/llgoext
 ) | tee -a "$go_results"
 
@@ -58,7 +61,7 @@ go_results="$result_directory/go.txt"
     -run '^$' \
     -bench '^BenchmarkGoroutine$' \
     -benchtime=100x \
-    -count=1 \
+    -count=3 \
     ./test/llgoext
 ) | tee -a "$go_results"
 


### PR DESCRIPTION
## Summary

- Check out the pull request base and head sequentially at the same source path and measure both in each platform job.
- Feed the paired result to `setup-benchmark-go-action@v1`, so the PR comment compares `vs base` from the same runner instead of historical data from another machine.
- Share dependency setup and Go build caches, warm program builds before timing, and report the median of five Go/LLGo microbenchmark samples.
- Keep main pushes at one suite and retain the existing 20-minute timeout.
- Consolidate the benchmark commands in `benchmark/baseline/run.sh` so both revisions use the same current-checkout harness.

The paired artifact/publisher support was added in [xgo-dev/setup-benchmark-go-action#3](https://github.com/xgo-dev/setup-benchmark-go-action/pull/3).

## Runtime impact

Across the latest 15 successful benchmark runs before this change:

| Platform | Median | Range | P90 |
| --- | ---: | ---: | ---: |
| Linux | 3m25s | 3m09s–3m34s | 3m32s |
| macOS | 3m44s | 3m19s–5m29s | 4m53s |

The first hosted paired run completed in 5m07s on Linux and 5m38s on macOS, about 50% above the previous medians rather than twice as long. After the review stability changes, Linux completed in 5m01s and macOS in 7m03s.

A complete local five-sample suite on macOS/Apple M4 Max took 87.72s, versus 69.93–73s with one sample. Thus main remains a single suite with roughly 15–20s added for warm-up and sampling, while PR jobs remain around 5–6 minutes with wide headroom under 20 minutes.

## Stability checks

The first paired report exposed false changes even though compiler code was unchanged: macOS `fmtprintf` build showed -48.6%, several microbenchmarks moved 20–35%, and binary sizes differed. The review update now:

- uses the exact same source path for base and head, eliminating path-dependent size differences;
- performs an unmeasured build warm-up before the three timed program builds;
- records five independent 250ms microbenchmark samples and reports their median;
- documents that very small changes still require confirmation across workflow runs.

On the refreshed Linux artifact, all binary size metrics are identical, microbenchmark deltas are 0–1.23%, and the largest program build/run delta is 2.50%.

## Validation

- `bash -n benchmark/baseline/run.sh`
- `shellcheck benchmark/baseline/run.sh`
- `actionlint .github/workflows/benchmark.yml`
- `go test ./benchmark/baseline -count=1`
- complete local relative-path benchmark suite and export with five samples
- action ingestion verification: five stored samples with the correct median
- end-to-end paired artifact rendering with real llgo output (`vs base`, trusted same-runner footer)
